### PR TITLE
Add support for PayHub Payment Gateway. Support transation purchase, voi...

### DIFF
--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -1,0 +1,231 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PayHubGateway < Gateway
+      self.live_url = 'https://checkout.payhub.com/transaction/api'
+      self.test_url = 'https://checkout.payhub.com/transaction/api'
+      
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'http://www.payhub.com/'
+      self.display_name = 'PayHub'
+
+      RESPONSE_CODE_TRANSLATOR = {
+        '00' => "Successful - Approved and completed",
+        "01" => "Failed - Refer to issuer",
+        "02" => "Failed - Refer to issuer-Special condition",
+        "03" => "Failed - Invalid Merchant ID",
+        "04" => "Failed - Pick up card (no fraud)",
+        "05" => "Failed - Do not honor",
+        "06" => "Failed - General error",
+        "06*" => "Failed - Error response text from check service",
+        "07" => "Failed - Pick up card, special condition (fraud account)",
+        "08" => "Successful - Honor MasterCard with ID",
+        "10" => "Failed - PayHub does not support partial approvals.",
+        "11" => "Successful - VIP approval",
+        "12" => "Failed - Invalid transaction",
+        "13" => "Failed - Invalid amount",
+        "14" => "Failed - Invalid card number",
+        "15" =>   "Failed - No such issuer",
+        "19" => "Failed - Re-enter transaction",
+        "21" => "Failed - Unable to back out transaction",
+        "28" => "Failed - File is temporarily unavailable",
+        "34" => "Failed - MasterCard use only, Transaction Cancelled; Fraud Concern (Used in reversal requests only)",
+        "39" => "Failed - No credit account",
+        "41" => "Failed - Lost card, pick up (fraud account)",
+        "43" => "Failed - Stolen card, pick up (fraud account)",
+        "51" => "Failed - Insufficient funds",
+        "52" => "Failed - No checking account",
+        "53" => "Failed - No savings account",
+        "54" => "Failed - Expired card",
+        "55" => "Failed - Incorrect PIN",
+        "57" => "Failed - Transaction not permitted-Card",
+        "58" => "Failed - Transaction not permitted-Terminal",
+        "59" => "Failed - Transaction not permitted-Merchant",
+        "61" => "Failed - Exceeds withdrawal limit",
+        "62" => "Failed - Invalid service code, restricted",
+        "63" => "Failed - Security violation",
+        "65" => "Failed - Activity limit exceeded",
+        "75" => "Failed - PIN tried exceeded",
+        "76" => "Failed - Unable to locate, no match",
+        "77" => "Failed - Inconsistent data, reversed, or repeat",
+        "78" => "Failed - No account",
+        "79" => "Failed - Already reversed at switch",
+        "80" => "Failed - Invalid date",
+        "81" => "Failed - Cryptographic error",
+        "82" => "Failed - CVV data is not correct",
+        "83" => "Failed - Cannot verify PIN",
+        "85" => "Successful - No reason to decline",
+        "86" => "Failed - Cannot verify PIN",
+        "91" => "Failed - Issuer or switch is unavailable",
+        "92" => "Failed - Destination not found",
+        "93" => "Failed - Violation, cannot complete",
+        "94" => "Failed - Unable to locate, no match",
+        "96" => "Failed - System malfunction"
+      }
+      
+      CVV_CODE_TRANSLATOR = {
+        'M' => 'CVV matches',
+        'N' => 'CVV does not match',
+        'P' => 'CVV not processed',
+        'S' => 'CVV should have been present',
+        'U' => 'CVV request unable to be processed by issuer'
+      }
+
+      AVS_CODE_TRANSLATOR = {
+        '0' =>  "Approved, Address verification was not requested.",
+        'A' =>  "Approved, Address matches only.",
+        'B' =>  "Address Match. Street Address math for international transaction Postal Code not verified because of incompatible formats (Acquirer sent both street address and Postal Code)",
+        'C' =>  "Serv Unavailable. Street address and Postal Code not verified for international transaction because of incompatible formats (Acquirer sent both street and Postal Code).",
+        'D' =>  "Exact Match, Street Address and Postal Code match for international transaction.",
+        'F' =>  "Exact Match, Street Address and Postal Code match. Applies to UK only.",
+        'G' =>  "Ver Unavailable, Non-U.S. Issuer does not participate.",
+        'I' =>  "Ver Unavailable, Address information not verified for international transaction",
+        'M' =>  "Exact Match, Street Address and Postal Code match for international transaction",
+        'N' =>  "No - Address and ZIP Code does not match",
+        'P' =>  "Zip Match, Postal Codes match for international transaction Street address not verified because of incompatible formats (Acquirer sent both street address and Postal Code).",
+        'R' =>  "Retry - Issuer system unavailable",
+        'S' =>  "Serv Unavailable, Service not supported",
+        'U' =>  "Ver Unavailable, Address unavailable.",
+        'W' =>  "ZIP match - Nine character numeric ZIP match only.",
+        'X' =>  "Exact match, Address and nine-character ZIP match.",
+        'Y' =>  "Exact Match, Address and five character ZIP match.",
+        'Z' =>  "Zip Match, Five character numeric ZIP match only.",
+        '1' =>  "Cardholder name and ZIP match AMEX only.",
+        '2' =>  "Cardholder name, address, and ZIP match AMEX only.",
+        '3' =>  "Cardholder name and address match AMEX only.",
+        '4' =>  "Cardholder name match AMEX only.",
+        '5' =>  "Cardholder name incorrect, ZIP match AMEX only.",
+        '6' =>  "Cardholder name incorrect, address and ZIP match AMEX only.",
+        '7' =>  "Cardholder name incorrect, address match AMEX only.",
+        '8' =>  "Cardholder, all do not match AMEX only." 
+      }
+
+      #STANDARD_ERROR_CODE_MAPPING = {}
+
+      def initialize(options={})
+        requires!(options, :orgid, :username, :password, :tid)
+        @orgid = options[:orgid]
+        @username = options[:username]
+        @password = options[:password]
+        @tid = options[:tid]
+        
+        super
+        
+        options[:mode] = test? ? 'demo' : 'live'
+      end
+
+      def purchase(money, creditcard, options={})
+        post = self.options
+        add_creditcard(post, creditcard)
+        add_amount(post, money, options)
+        add_address(post, options.delete(:address))
+        add_customer_data(post, options)
+
+        post[:trans_type] = 'sale'
+
+        commit(:post, post, options)
+      end
+
+      [:refund, :void].each do |action|
+        define_method(action) do |options={}|
+          requires!(options, :trans_id)
+          post = self.options
+          post[:trans_id] = options[:trans_id]
+          post[:trans_type] = action.to_s
+
+          commit(:post, post, options)
+        end
+      end
+
+      private
+
+      def add_customer_data(post, options)
+        return unless options.kind_of?(Hash)
+        post[:first_name] = options.delete(:first_name) if options[:first_name]
+        post[:last_name] = options.delete(:last_name) if options[:last_name]
+        post[:phone] = options.delete(:phone) if options[:phone]
+        post[:email] = options.delete(:email) if options[:email]
+      end
+
+      def add_address(post, address)
+        return unless card_exists?(post) && address.kind_of?(Hash)
+        post[:address1] = address[:address1] if address[:address1]
+        post[:address2] = address[:address2] if address[:address2]
+        post[:zip] = address[:zip] if address[:zip]
+        post[:state] = address[:state] if address[:state]
+        post[:city] = address[:city] if address[:city]
+      end
+
+      def card_exists?(post)
+        post[:cc] && post[:month] && post[:year] && post[:cvv]
+      end
+
+      def add_amount(post, money, options)
+        post[:amount] =  amount(money)
+      end
+
+      def add_creditcard(post, creditcard)
+        post[:cc] = creditcard.number
+        post[:month] = creditcard.month.to_s
+        post[:year] = creditcard.year.to_s
+        post[:cvv] = creditcard.verification_value if creditcard.verification_value?
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def commit(action, parameters, options={})
+        parameters.merge!(options)
+        # We really don't need. Just incase if payhub have different end points
+        url = (test? ? test_url : live_url)
+
+        raw_response = response = nil
+        success = false
+        begin
+          raw_response = ssl_request(action, url, parameters.to_json, {'Content-Type' => 'application/json'} )
+          response = parse(raw_response)
+          success = response['RESPONSE_CODE'] == "00"
+        rescue ResponseError => e
+          raw_response = e.response.body
+          response = response_error(raw_response)
+        rescue JSON::ParserError
+          response = json_error(raw_response)
+        end
+
+        Response.new(success,
+          response_message(response),
+          response,
+          :test => test?,
+          :avs_result => { :code => response['AVS_RESULT_CODE'] },
+          :cvv_result => response['VERIFICATION_RESULT_CODE'],
+          :error_code => success ? nil : response['RESPONSE_CODE']
+        )
+      end
+
+      def response_error(raw_response)
+        begin
+          parse(raw_response)
+        rescue JSON::ParserError
+          json_error(raw_response)
+        end
+      end
+
+      def json_error(raw_response)
+        msg = 'Invalid response received from the Payhub API.  Please contact wecare@payhub.com if you continue to receive this message.'
+        msg.concat '  (The raw response returned by the API was #{raw_response.inspect})'
+        {
+          'error' => {
+            'message' => msg
+          }
+        }
+      end
+
+      def response_message(response)
+        RESPONSE_CODE_TRANSLATOR[response['RESPONSE_CODE']] || response['RESPONSE_TEXT'] || response['error']['message']
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -2,8 +2,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PayHubGateway < Gateway
       self.live_url = 'https://checkout.payhub.com/transaction/api'
-      self.test_url = 'https://checkout.payhub.com/transaction/api'
-      
+
       self.supported_countries = ['US']
       self.default_currency = 'USD'
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
@@ -11,60 +10,6 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.payhub.com/'
       self.display_name = 'PayHub'
 
-      RESPONSE_CODE_TRANSLATOR = {
-        '00' => "Successful - Approved and completed",
-        "01" => "Failed - Refer to issuer",
-        "02" => "Failed - Refer to issuer-Special condition",
-        "03" => "Failed - Invalid Merchant ID",
-        "04" => "Failed - Pick up card (no fraud)",
-        "05" => "Failed - Do not honor",
-        "06" => "Failed - General error",
-        "06*" => "Failed - Error response text from check service",
-        "07" => "Failed - Pick up card, special condition (fraud account)",
-        "08" => "Successful - Honor MasterCard with ID",
-        "10" => "Failed - PayHub does not support partial approvals.",
-        "11" => "Successful - VIP approval",
-        "12" => "Failed - Invalid transaction",
-        "13" => "Failed - Invalid amount",
-        "14" => "Failed - Invalid card number",
-        "15" =>   "Failed - No such issuer",
-        "19" => "Failed - Re-enter transaction",
-        "21" => "Failed - Unable to back out transaction",
-        "28" => "Failed - File is temporarily unavailable",
-        "34" => "Failed - MasterCard use only, Transaction Cancelled; Fraud Concern (Used in reversal requests only)",
-        "39" => "Failed - No credit account",
-        "41" => "Failed - Lost card, pick up (fraud account)",
-        "43" => "Failed - Stolen card, pick up (fraud account)",
-        "51" => "Failed - Insufficient funds",
-        "52" => "Failed - No checking account",
-        "53" => "Failed - No savings account",
-        "54" => "Failed - Expired card",
-        "55" => "Failed - Incorrect PIN",
-        "57" => "Failed - Transaction not permitted-Card",
-        "58" => "Failed - Transaction not permitted-Terminal",
-        "59" => "Failed - Transaction not permitted-Merchant",
-        "61" => "Failed - Exceeds withdrawal limit",
-        "62" => "Failed - Invalid service code, restricted",
-        "63" => "Failed - Security violation",
-        "65" => "Failed - Activity limit exceeded",
-        "75" => "Failed - PIN tried exceeded",
-        "76" => "Failed - Unable to locate, no match",
-        "77" => "Failed - Inconsistent data, reversed, or repeat",
-        "78" => "Failed - No account",
-        "79" => "Failed - Already reversed at switch",
-        "80" => "Failed - Invalid date",
-        "81" => "Failed - Cryptographic error",
-        "82" => "Failed - CVV data is not correct",
-        "83" => "Failed - Cannot verify PIN",
-        "85" => "Successful - No reason to decline",
-        "86" => "Failed - Cannot verify PIN",
-        "91" => "Failed - Issuer or switch is unavailable",
-        "92" => "Failed - Destination not found",
-        "93" => "Failed - Violation, cannot complete",
-        "94" => "Failed - Unable to locate, no match",
-        "96" => "Failed - System malfunction"
-      }
-      
       CVV_CODE_TRANSLATOR = {
         'M' => 'CVV matches',
         'N' => 'CVV does not match',
@@ -99,91 +44,132 @@ module ActiveMerchant #:nodoc:
         '5' =>  "Cardholder name incorrect, ZIP match AMEX only.",
         '6' =>  "Cardholder name incorrect, address and ZIP match AMEX only.",
         '7' =>  "Cardholder name incorrect, address match AMEX only.",
-        '8' =>  "Cardholder, all do not match AMEX only." 
+        '8' =>  "Cardholder, all do not match AMEX only."
+      }
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        '14' => STANDARD_ERROR_CODE[:invalid_number],
+        '80' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        '82' => STANDARD_ERROR_CODE[:invalid_cvc],
+        '54' => STANDARD_ERROR_CODE[:expired_card],
+        '51' => STANDARD_ERROR_CODE[:card_declined],
+        '05' => STANDARD_ERROR_CODE[:card_declined],
+        '61' => STANDARD_ERROR_CODE[:card_declined],
+        '62' => STANDARD_ERROR_CODE[:card_declined],
+        '65' => STANDARD_ERROR_CODE[:card_declined],
+        '93' => STANDARD_ERROR_CODE[:card_declined],
+        '01' => STANDARD_ERROR_CODE[:call_issuer],
+        '02' => STANDARD_ERROR_CODE[:call_issuer],
+        '04' => STANDARD_ERROR_CODE[:pickup_card],
+        '07' => STANDARD_ERROR_CODE[:pickup_card],
+        '41' => STANDARD_ERROR_CODE[:pickup_card],
+        '43' => STANDARD_ERROR_CODE[:pickup_card]
       }
 
       def initialize(options={})
         requires!(options, :orgid, :username, :password, :tid)
-        @orgid = options[:orgid]
-        @username = options[:username]
-        @password = options[:password]
-        @tid = options[:tid]
-        
+
         super
-        
-        options[:mode] = test? ? 'demo' : 'live'
       end
 
-      def purchase(money, creditcard, options={})
-        post = self.options
-        add_creditcard(post, creditcard)
-        add_amount(post, money, options)
-        add_address(post, options.delete(:address))
-        add_customer_data(post, options)
+      def authorize(amount, creditcard, options = {})
+        post = add_credentials_for_auth_or_purchase(amount, creditcard, options)
+        post[:trans_type] = 'auth'
 
+        commit(:post, post, options)
+      end
+
+      def purchase(amount, creditcard, options={})
+        post = add_credentials_for_auth_or_purchase(amount, creditcard, options)
         post[:trans_type] = 'sale'
 
         commit(:post, post, options)
       end
 
-      [:refund, :void].each do |action|
-        define_method(action) do |options={}|
-          requires!(options, :trans_id)
-          post = self.options
-          post[:trans_id] = options[:trans_id]
-          post[:trans_type] = action.to_s
+      def refund(trans_id, options={})
+        post = add_credentials_for('refund', trans_id)
 
-          commit(:post, post, options)
-        end
+        commit(:post, post, options)
+      end
+
+      def void(trans_id, options={})
+        post = add_credentials_for('void', trans_id)
+
+        commit(:post, post, options)
+      end
+
+      def capture(trans_id, options = {})
+        post = add_credentials_for('capture', trans_id)
+        add_amount(post, options[:amount])
+
+        commit(:post, post, options)
       end
 
       private
 
-      def add_customer_data(post, options)
-        return unless options.kind_of?(Hash)
-        post[:first_name] = options.delete(:first_name) if options[:first_name]
-        post[:last_name] = options.delete(:last_name) if options[:last_name]
-        post[:phone] = options.delete(:phone) if options[:phone]
-        post[:email] = options.delete(:email) if options[:email]
+      def add_credentials_for_auth_or_purchase(amount, creditcard, options = {})
+        post = {}
+        add_credentials(post)
+        add_creditcard(post, creditcard)
+        add_amount(post, amount)
+        add_address(post, options.delete(:address))
+        add_customer_data(post, options)
+        post
       end
 
-      def add_address(post, address)
-        return unless card_exists?(post) && address.kind_of?(Hash)
-        post[:address1] = address[:address1] if address[:address1]
-        post[:address2] = address[:address2] if address[:address2]
-        post[:zip] = address[:zip] if address[:zip]
-        post[:state] = address[:state] if address[:state]
-        post[:city] = address[:city] if address[:city]
+      def add_credentials(post)
+        post[:orgid] = @options[:orgid]
+        post[:tid] = @options[:tid]
+        post[:username] = @options[:username]
+        post[:password] = @options[:password]
       end
 
-      def card_exists?(post)
-        post[:cc] && post[:month] && post[:year] && post[:cvv]
+      def add_credentials_for(action, trans_id)
+        post = {}
+        add_credentials(post)
+        post[:trans_id] = trans_id
+        post[:trans_type] = action
+        post
       end
 
-      def add_amount(post, money, options)
-        post[:amount] =  amount(money)
+      def add_customer_data(post, options = {})
+        post[:first_name] = options.delete(:first_name)
+        post[:last_name] = options.delete(:last_name)
+        post[:phone] = options.delete(:phone)
+        post[:email] = options.delete(:email)
+      end
+
+      def add_address(post, address = {})
+        post[:address1] = address[:address1]
+        post[:address2] = address[:address2]
+        post[:zip] = address[:zip]
+        post[:state] = address[:state]
+        post[:city] = address[:city]
+      end
+
+      def add_amount(post, amount)
+        post[:amount] =  amount(amount)
       end
 
       def add_creditcard(post, creditcard)
         post[:cc] = creditcard.number
         post[:month] = creditcard.month.to_s
         post[:year] = creditcard.year.to_s
-        post[:cvv] = creditcard.verification_value if creditcard.verification_value?
+        post[:cvv] = creditcard.verification_value
       end
 
       def parse(body)
         JSON.parse(body)
       end
 
-      def commit(action, parameters, options={})
-        parameters.merge!(options)
-        # We really don't need. Just incase if payhub have different end points
-        url = (test? ? test_url : live_url)
-
+      def commit(action, post, options={})
+        add_mode(post)
+        post.merge!(options)
         raw_response = response = nil
         success = false
+
         begin
-          raw_response = ssl_request(action, url, parameters.to_json, {'Content-Type' => 'application/json'} )
+          raw_response = ssl_request(action, live_url, post.to_json, {'Content-Type' => 'application/json'} )
           response = parse(raw_response)
           success = response['RESPONSE_CODE'] == "00"
         rescue ResponseError => e
@@ -199,8 +185,12 @@ module ActiveMerchant #:nodoc:
           :test => test?,
           :avs_result => { :code => response['AVS_RESULT_CODE'] },
           :cvv_result => response['VERIFICATION_RESULT_CODE'],
-          :error_code => success ? nil : response['RESPONSE_CODE']
+          :error_code => success ? nil : STANDARD_ERROR_CODE_MAPPING[response['RESPONSE_CODE']]
         )
+      end
+
+      def add_mode(post)
+        post[:mode] = test? ? 'demo' : 'live'
       end
 
       def response_error(raw_response)
@@ -222,7 +212,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def response_message(response)
-        RESPONSE_CODE_TRANSLATOR[response['RESPONSE_CODE']] || response['RESPONSE_TEXT'] || response['error']['message']
+        response['RESPONSE_TEXT'] || response["RESPONSE_CODE"] || response['error']['message']
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -86,8 +86,6 @@ module ActiveMerchant #:nodoc:
         commit(:post, post, options)
       end
 
-      # Since Payhub does not support partial refund,
-      # method signature shouldn't include amount parameter
       def refund(amount, trans_id, options={})
         post = add_credentials_for('refund', trans_id)
         add_amount(post, amount)

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -88,8 +88,9 @@ module ActiveMerchant #:nodoc:
 
       # Since Payhub does not support partial refund,
       # method signature shouldn't include amount parameter
-      def refund(trans_id, options={})
+      def refund(amount, trans_id, options={})
         post = add_credentials_for('refund', trans_id)
+        add_amount(post, amount)
 
         commit(:post, post, options)
       end

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -102,8 +102,6 @@ module ActiveMerchant #:nodoc:
         '8' =>  "Cardholder, all do not match AMEX only." 
       }
 
-      #STANDARD_ERROR_CODE_MAPPING = {}
-
       def initialize(options={})
         requires!(options, :orgid, :username, :password, :tid)
         @orgid = options[:orgid]

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -459,6 +459,13 @@ payment_express:
   login: LOGIN
   password: PASSWORD
 
+# Working credentials, no need to replace
+pay_hub:
+  orgid: "123456"
+  username: "abc123DEF"
+  password: "abc123DEF"
+  tid: "123"
+  
 paymill:
   private_key: PRIVATE_KEY
   public_key: PUBLIC_KEY

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -428,6 +428,13 @@ pay_gate_xml:
   password: 'test'
 
 # Working credentials, no need to replace
+pay_hub:
+  orgid: '123456'
+  username: 'abc123DEF'
+  password: 'abc123DEF'
+  tid: '123'
+
+# Working credentials, no need to replace
 pay_junction:
   login: 'pj-ql-01'
   password: 'pj-ql-01p'
@@ -459,13 +466,6 @@ payment_express:
   login: LOGIN
   password: PASSWORD
 
-# Working credentials, no need to replace
-pay_hub:
-  orgid: "123456"
-  username: "abc123DEF"
-  password: "abc123DEF"
-  tid: "123"
-  
 paymill:
   private_key: PRIVATE_KEY
   public_key: PUBLIC_KEY

--- a/test/remote/gateways/remote_pay_hub_test.rb
+++ b/test/remote/gateways/remote_pay_hub_test.rb
@@ -3,17 +3,11 @@ require 'test_helper'
 class RemotePayHubTest < Test::Unit::TestCase
   def setup
     @gateway = PayHubGateway.new(fixtures(:pay_hub))
-
     @amount = 100
-
-    @credit_card = credit_card('5466410004374507', :month => '06', 
-                               :year => '2020', :verification_value => '998')
-
-    @invalid_amount_card = credit_card('371449635398431', :month => '06', 
-                               :year => '2020', :verification_value => '9997')
-
+    @credit_card = credit_card('5466410004374507', valid_credit_card_credentials)
+    @invalid_amount_card = credit_card('371449635398431', invalid_credit_card_credentials)
     @options = {
-      :first_name=> 'Garrya',
+      :first_name => 'Garrya',
       :last_name => 'Barrya',
       :email => 'payhubtest@mailinator.com',
       :address => {
@@ -27,44 +21,104 @@ class RemotePayHubTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
+
     assert_success response
     assert response.success?
-    assert_equal 'Successful - Approved and completed', response.message
+    assert_equal 'SUCCESS', response.message
   end
 
-  def test_failed_purchase
-    @amount = 0.20
-    response = @gateway.purchase(@amount, @invalid_amount_card, @options)
+  def test_unsuccessful_purchase
+    amount = 0.20
+    response = @gateway.purchase(amount, @invalid_amount_card, @options)
+
     assert !response.success?
     assert_equal 'INVALID AMOUNT', response.message
   end
 
-  def test_successful_void
-    response = @gateway.purchase(@amount, @credit_card, @options)
-    response = @gateway.void(:trans_id => response.params['TRANSACTION_ID'])
+  def test_successful_auth
+    response = @gateway.authorize(@amount, @credit_card, @options)
+
     assert_success response
     assert response.success?
-    assert_equal 'Successful - Approved and completed', response.message
+    assert_equal 'SUCCESS', response.message
   end
 
-  def test_failed_void
-    response = @gateway.void(:trans_id => 347)
+  def test_unsuccessful_auth
+    amount = 0.20
+    response = @gateway.authorize(amount, @credit_card, @options)
+
+    assert !response.success?
+    assert_equal 'INVALID AMOUNT', response.message
+  end
+
+
+  def test_unsuccessful_capture
+    response = @gateway.capture( 123 )
+
+    assert_failure response
+    assert !response.success?
+    assert_equal 'UNABLE TO CAPTURE', response.message
+  end
+
+  def test_partial_capture
+    auth_response = @gateway.authorize(@amount, @credit_card, @options)
+
+    response = @gateway.capture(auth_response.params['TRANSACTION_ID'], { :amount => 10 })
+
+    assert_success response
+    assert response.success?
+    assert_equal 'TRANSACTION CAPTURED SUCCESSFULLY', response.message
+  end
+
+  def test_successful_void
+    purchase_response = @gateway.purchase(@amount, @credit_card, @options)
+
+    response = @gateway.void(purchase_response.params['TRANSACTION_ID'])
+
+    assert_success response
+    assert response.success?
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_unsuccessful_void
+    response = @gateway.void(347)
+
     assert_failure response
     assert !response.success?
     assert_equal 'Unable to void previous transaction.', response.message
   end
 
   def test_successful_refund
-    response = @gateway.refund(:trans_id => 123)
+    response = @gateway.refund(123)
+
     assert_success response
     assert response.success?
-    assert_equal 'Successful - Approved and completed', response.message
+    assert_equal 'SUCCESS', response.message
   end
 
-  def test_failed_refund
-    response = @gateway.refund(:trans_id => 981)
+  def test_unsuccessful_refund
+    response = @gateway.refund(981)
+
     assert_failure response
     assert !response.success?
     assert_equal 'Unable to refund the previous transaction.', response.message
+  end
+
+  private
+
+  def valid_credit_card_credentials
+    {
+      :month => '06',
+      :year => '2020',
+      :verification_value => '998'
+    }
+  end
+
+  def invalid_credit_card_credentials
+    {
+      :month => '06',
+      :year => '2020',
+      :verification_value => '9997'
+    }
   end
 end

--- a/test/remote/gateways/remote_pay_hub_test.rb
+++ b/test/remote/gateways/remote_pay_hub_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class RemotePayHubTest < Test::Unit::TestCase
+  def setup
+    @gateway = PayHubGateway.new(fixtures(:pay_hub))
+
+    @amount = 100
+
+    @credit_card = credit_card('5466410004374507', :month => '06', 
+                               :year => '2020', :verification_value => '998')
+
+    @invalid_amount_card = credit_card('371449635398431', :month => '06', 
+                               :year => '2020', :verification_value => '9997')
+
+    @options = {
+      :first_name=> 'Garrya',
+      :last_name => 'Barrya',
+      :email => 'payhubtest@mailinator.com',
+      :address => {
+        :address1 => '123a ahappy St.',
+        :city => 'Happya City',
+        :state => 'CA',
+        :zip => '94901'
+      }
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert response.success?
+    assert_equal 'Successful - Approved and completed', response.message
+  end
+
+  def test_failed_purchase
+    @amount = 0.20
+    response = @gateway.purchase(@amount, @invalid_amount_card, @options)
+    assert !response.success?
+    assert_equal 'INVALID AMOUNT', response.message
+  end
+
+  def test_successful_void
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    response = @gateway.void(:trans_id => response.params['TRANSACTION_ID'])
+    assert_success response
+    assert response.success?
+    assert_equal 'Successful - Approved and completed', response.message
+  end
+
+  def test_failed_void
+    response = @gateway.void(:trans_id => 347)
+    assert_failure response
+    assert !response.success?
+    assert_equal 'Unable to void previous transaction.', response.message
+  end
+
+  def test_successful_refund
+    response = @gateway.refund(:trans_id => 123)
+    assert_success response
+    assert response.success?
+    assert_equal 'Successful - Approved and completed', response.message
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(:trans_id => 981)
+    assert_failure response
+    assert !response.success?
+    assert_equal 'Unable to refund the previous transaction.', response.message
+  end
+end

--- a/test/remote/gateways/remote_pay_hub_test.rb
+++ b/test/remote/gateways/remote_pay_hub_test.rb
@@ -90,7 +90,7 @@ class RemotePayHubTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    response = @gateway.refund(123)
+    response = @gateway.refund(@amount, 123)
 
     assert_success response
     assert response.success?
@@ -98,8 +98,7 @@ class RemotePayHubTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_refund
-    response = @gateway.refund(981)
-
+    response = @gateway.refund(@amount, 981)
     assert_failure response
     assert !response.success?
     assert_equal 'Unable to refund the previous transaction.', response.message

--- a/test/remote/gateways/remote_pay_hub_test.rb
+++ b/test/remote/gateways/remote_pay_hub_test.rb
@@ -53,7 +53,7 @@ class RemotePayHubTest < Test::Unit::TestCase
 
 
   def test_unsuccessful_capture
-    response = @gateway.capture( 123 )
+    response = @gateway.capture(@amount, 123)
 
     assert_failure response
     assert !response.success?
@@ -61,9 +61,10 @@ class RemotePayHubTest < Test::Unit::TestCase
   end
 
   def test_partial_capture
+    amount = 10
     auth_response = @gateway.authorize(@amount, @credit_card, @options)
 
-    response = @gateway.capture(auth_response.params['TRANSACTION_ID'], { :amount => 10 })
+    response = @gateway.capture(amount, auth_response.authorization)
 
     assert_success response
     assert response.success?
@@ -73,7 +74,7 @@ class RemotePayHubTest < Test::Unit::TestCase
   def test_successful_void
     purchase_response = @gateway.purchase(@amount, @credit_card, @options)
 
-    response = @gateway.void(purchase_response.params['TRANSACTION_ID'])
+    response = @gateway.void(purchase_response.authorization)
 
     assert_success response
     assert response.success?

--- a/test/unit/gateways/pay_hub_test.rb
+++ b/test/unit/gateways/pay_hub_test.rb
@@ -1,0 +1,307 @@
+require 'test_helper'
+
+class PayHubTest < Test::Unit::TestCase
+  def setup
+    @gateway = PayHubGateway.new( 
+                                  :orgid => "123456",
+                                  :username=>"abc123DEF",
+                                  :password=>"abc123DEF",
+                                  :tid => '123'
+                                )
+
+    @credit_card = credit_card('371449635398431',
+                      :first_name => 'Bob',
+                      :last_name => 'Bobsen',
+                      :month => '06',
+                      :year => '2020',
+                      :verification_value => '9997'
+                      )
+    @amount = 200
+
+    @options =
+    {
+      :first_name=> 'Garry',
+      :last_name => 'Barry',
+      :phone => '9179328589',
+      :email => 'abcsss@mailinator.com',
+      :address =>
+      {
+        :address1 => '123 ahappy St.',
+        :address2 => 'Abca',
+        :city => 'aHappy City',
+        :state => 'CA',
+        :zip => '94901'
+      }
+    }
+  end
+
+  def test_unsuccessful_request
+    @gateway.expects(:ssl_request).returns(failed_purchase_response)
+    @gateway.options.merge!({:mode => 'live', :test => false})
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert !response.success?
+
+    assert !response.test?
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    
+    assert_success response
+
+    assert response.test?
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_request).returns(successful_void_response)
+
+    response = @gateway.void(:trans_id => "479")
+
+    assert_success response
+
+    assert response.test?
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_request).returns(successful_refund_response)
+
+    response = @gateway.void(:trans_id => "123")
+
+    assert_success response
+
+    assert response.test?
+  end
+
+  def test_invalid_raw_response
+    @gateway.expects(:ssl_request).returns(invalid_json_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    
+    assert_failure response
+    
+    assert_match(/^Invalid response received from the Payhub API/, response.message.to_s)
+  end
+
+  def test_message_for_response_codes
+    PayHubGateway::RESPONSE_CODE_TRANSLATOR.keys.each do |code|
+       @gateway.expects(:ssl_request).returns(json_response_for_codes(code))
+
+      response = @gateway.purchase(@amount, @credit_card, @options)
+
+      assert response.test?
+
+      assert_match(PayHubGateway::RESPONSE_CODE_TRANSLATOR[code] ,response.message)
+    end
+  end
+
+  def test_response_for_avs_codes
+    PayHubGateway::AVS_CODE_TRANSLATOR.keys.each do |code|
+       @gateway.expects(:ssl_request).returns(json_response_for_avs_codes(code))
+
+      response = @gateway.purchase(@amount, @credit_card, @options)
+
+      assert response.test?
+
+      assert_match(code ,response.avs_result['code'])
+    end
+  end
+
+  def test_response_for_cvv_codes
+    PayHubGateway::CVV_CODE_TRANSLATOR.keys.each do |code|
+       @gateway.expects(:ssl_request).returns(json_response_for_cvv_codes(code))
+
+      response = @gateway.purchase(@amount, @credit_card, @options)
+
+      assert response.test?
+
+      assert_match(code ,response.cvv_result['code'])
+      
+      assert_match(PayHubGateway::CVV_CODE_TRANSLATOR[code] ,response.cvv_result['message'])
+    end
+  end
+
+  def test_unsuccessful_void
+    @gateway.expects(:ssl_request).returns(json_response_for_unsuccessful_void)
+
+    assert response = @gateway.void(:trans_id => 123)
+
+    assert response.test?
+
+    assert_failure response
+    
+    assert_match(/^Unable to void previous transaction./, response.message.to_s)
+  end
+
+  def test_unsuccessful_refund
+    @gateway.expects(:ssl_request).returns(json_response_for_unsuccessful_refund)
+
+    assert response = @gateway.refund(:trans_id => 123)
+
+    assert response.test?
+
+    assert_failure response
+
+    assert_match(/^Unable to refund the previous transaction./, response.message.to_s)
+  end
+
+  private
+
+  def json_response_for_unsuccessful_void
+    <<-RESPONSE
+    {
+    "CARD_TOKEN_NO": "9999000000001705",
+    "AVS_RESULT_CODE": "N",
+    "TRANSACTION_ID": "7525",
+    "CUSTOMER_ID": "136",
+    "VERIFICATION_RESULT_CODE": "M",
+    "RESPONSE_CODE": "4073",
+    "RISK_STATUS_RESPONSE_CODE": "",
+    "TRANSACTION_DATE_TIME": "110914 101145",
+    "RISK_STATUS_RESPONSE_TEXT": "",
+    "APPROVAL_CODE": "TAS725",
+    "BATCH_ID": "420",
+    "RESPONSE_TEXT": "Unable to void previous transaction.",
+    "CIS_NOTE": ""
+    }
+    RESPONSE
+  end
+
+  def json_response_for_unsuccessful_refund
+    <<-RESPONSE
+    {
+    "CARD_TOKEN_NO": "",
+    "AVS_RESULT_CODE": "",
+    "TRANSACTION_ID": "",
+    "CUSTOMER_ID": "",
+    "VERIFICATION_RESULT_CODE": "",
+    "RESPONSE_CODE": "4074",
+    "RISK_STATUS_RESPONSE_CODE": "",
+    "TRANSACTION_DATE_TIME": "",
+    "RISK_STATUS_RESPONSE_TEXT": "",
+    "APPROVAL_CODE": "",
+    "BATCH_ID": "",
+    "RESPONSE_TEXT": "Unable to refund the previous transaction.",
+    "CIS_NOTE": ""
+    }
+    RESPONSE
+  end
+
+  def json_response_for_cvv_codes(code)
+    <<-RESPONSE
+    {
+    "RESPONSE_CODE": "00",
+    "RESPONSE_TEXT": "SUCCESS",
+    "VERIFICATION_RESULT_CODE": "#{code}"
+    }
+    RESPONSE
+  end
+
+  def json_response_for_avs_codes(code)
+    <<-RESPONSE
+    {
+    "RESPONSE_CODE": "00",
+    "RESPONSE_TEXT": "SUCCESS",
+    "AVS_RESULT_CODE": "#{code}"
+    }
+    RESPONSE
+  end
+
+  def json_response_for_codes(response_code)
+    <<-RESPONSE
+    {
+    "RESPONSE_CODE": "#{response_code}",
+    "RESPONSE_TEXT": "#{PayHubGateway::RESPONSE_CODE_TRANSLATOR[response_code]}"
+    }
+    RESPONSE
+  end
+
+  def successful_purchase_response
+    <<-RESPONSE
+    {
+    "CARD_TOKEN_NO": "9999000000001033",
+    "AVS_RESULT_CODE": "N",
+    "TRANSACTION_ID":  "479",
+    "CUSTOMER_ID": "18",
+    "VERIFICATION_RESULT_CODE": "M",
+    "RESPONSE_CODE": "00",
+    "RISK_STATUS_RESPONSE_CODE": "",
+    "TRANSACTION_DATE_TIME": #{Time.now.year + 1},
+    "RISK_STATUS_RESPONSE_TEXT": "",
+    "APPROVAL_CODE": "TAS214",
+    "BATCH_ID": "97",
+    "RESPONSE_TEXT": "SUCCESS",
+    "CIS_NOTE": ""
+    }
+    RESPONSE
+  end
+
+  def failed_purchase_response
+    <<-RESPONSE
+    {
+    "CARD_TOKEN_NO": "",
+    "AVS_RESULT_CODE": "",
+    "TRANSACTION_ID": "",
+    "CUSTOMER_ID": "", 
+    "VERIFICATION_RESULT_CODE": "",
+    "RESPONSE_CODE": "4008",
+    "RISK_STATUS_RESPONSE_CODE": "", 
+    "TRANSACTION_DATE_TIME": "",
+    "RISK_STATUS_RESPONSE_TEXT"=>"",
+    "APPROVAL_CODE"=>"",
+    "BATCH_ID"=>"",
+    "RESPONSE_TEXT"=>"Invalid API Username.  Please contact the merchant.",
+    "CIS_NOTE"=>""
+    }
+    RESPONSE
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+    {
+    "CARD_TOKEN_NO": "9999000000001705",
+    "AVS_RESULT_CODE": "0",
+    "TRANSACTION_ID": "7522",
+    "CUSTOMER_ID": "136",
+    "VERIFICATION_RESULT_CODE": "",
+    "RESPONSE_CODE": "00",
+    "RISK_STATUS_RESPONSE_CODE": "",
+    "TRANSACTION_DATE_TIME": "2014-11-07 21:55:34",
+    "RISK_STATUS_RESPONSE_TEXT": "",
+    "APPROVAL_CODE": "TAS444",
+    "BATCH_ID": "416",
+    "RESPONSE_TEXT": "SUCCESS", 
+    "CIS_NOTE": ""
+    }
+    RESPONSE
+  end
+
+  def successful_refund_response
+    <<-RESPONSE
+    {
+    "CARD_TOKEN_NO": "9999000000001034",
+    "AVS_RESULT_CODE": "0",
+    "TRANSACTION_ID": "7523",
+    "CUSTOMER_ID": "",
+    "VERIFICATION_RESULT_CODE": "",
+    "RESPONSE_CODE": "00",
+    "RISK_STATUS_RESPONSE_CODE": "",
+    "TRANSACTION_DATE_TIME": "2014-11-07 21:58:35",
+    "RISK_STATUS_RESPONSE_TEXT": "",
+    "APPROVAL_CODE": "      ",
+    "BATCH_ID": "417",
+    "RESPONSE_TEXT": "SUCCESS", 
+    "CIS_NOTE": ""
+    }
+    RESPONSE
+  end
+
+  def invalid_json_response
+    <<-RESPONSE
+    "foo" =>  "bar"
+    RESPONSE
+  end
+end

--- a/test/unit/gateways/pay_hub_test.rb
+++ b/test/unit/gateways/pay_hub_test.rb
@@ -71,7 +71,7 @@ class PayHubTest < Test::Unit::TestCase
   def test_successful_refund
     @gateway.expects(:ssl_request).returns(successful_refund_response)
 
-    response = @gateway.void(123)
+    response = @gateway.refund(@amount, 123)
 
     assert_success response
     assert response.test?
@@ -81,7 +81,7 @@ class PayHubTest < Test::Unit::TestCase
   def test_unsuccessful_refund
     @gateway.expects(:ssl_request).returns(failed_refund_response)
 
-    assert response = @gateway.refund(123)
+    assert response = @gateway.refund(@amount, 123)
 
     assert response.test?
     assert_failure response

--- a/test/unit/gateways/pay_hub_test.rb
+++ b/test/unit/gateways/pay_hub_test.rb
@@ -29,7 +29,7 @@ class PayHubTest < Test::Unit::TestCase
   def test_successful_capture
     @gateway.expects(:ssl_request).returns(successful_capture_response)
 
-    response = @gateway.capture(123)
+    response = @gateway.capture(@amount, 123)
 
     assert_success response
     assert response.test?
@@ -37,9 +37,10 @@ class PayHubTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_capture
+    amount = 200
     @gateway.expects(:ssl_request).returns(failed_capture_response)
 
-    response = @gateway.capture(123, {:amount => 200})
+    response = @gateway.capture(amount, 123)
 
     assert !response.success?
     assert response.test?

--- a/test/unit/gateways/pay_hub_test.rb
+++ b/test/unit/gateways/pay_hub_test.rb
@@ -2,155 +2,215 @@ require 'test_helper'
 
 class PayHubTest < Test::Unit::TestCase
   def setup
-    @gateway = PayHubGateway.new( 
-                                  :orgid => "123456",
-                                  :username=>"abc123DEF",
-                                  :password=>"abc123DEF",
-                                  :tid => '123'
-                                )
-
-    @credit_card = credit_card('371449635398431',
-                      :first_name => 'Bob',
-                      :last_name => 'Bobsen',
-                      :month => '06',
-                      :year => '2020',
-                      :verification_value => '9997'
-                      )
+    @gateway = PayHubGateway.new(add_credentials)
+    @credit_card = credit_card('371449635398431', credit_card_params)
     @amount = 200
-
-    @options =
-    {
-      :first_name=> 'Garry',
-      :last_name => 'Barry',
-      :phone => '9179328589',
-      :email => 'abcsss@mailinator.com',
-      :address =>
-      {
-        :address1 => '123 ahappy St.',
-        :address2 => 'Abca',
-        :city => 'aHappy City',
-        :state => 'CA',
-        :zip => '94901'
-      }
-    }
-  end
-
-  def test_unsuccessful_request
-    @gateway.expects(:ssl_request).returns(failed_purchase_response)
-    @gateway.options.merge!({:mode => 'live', :test => false})
-
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
-
-    assert !response.success?
-
-    assert !response.test?
+    @options = optional_params
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+    @gateway.expects(:ssl_request).returns(successful_purchase_or_authorize_response)
 
     response = @gateway.purchase(@amount, @credit_card, @options)
-    
     assert_success response
-
     assert response.test?
+    assert_match(/^SUCCESS/, response.message.to_s)
   end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_request).returns(successful_purchase_or_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert response.test?
+    assert_match(/^SUCCESS/, response.message.to_s)
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_request).returns(successful_capture_response)
+
+    response = @gateway.capture(123)
+
+    assert_success response
+    assert response.test?
+    assert_match(/^TRANSACTION CAPTURED SUCCESSFULLY/, response.message.to_s)
+  end
+
+  def test_unsuccessful_capture
+    @gateway.expects(:ssl_request).returns(failed_capture_response)
+
+    response = @gateway.capture(123, {:amount => 200})
+
+    assert !response.success?
+    assert response.test?
+    assert_match(/^UNABLE TO CAPTURE/, response.message.to_s)
+  end
+
 
   def test_successful_void
     @gateway.expects(:ssl_request).returns(successful_void_response)
 
-    response = @gateway.void(:trans_id => "479")
+    response = @gateway.void(479)
 
     assert_success response
+    assert response.test?
+    assert_match(/^SUCCESS/, response.message.to_s)
+  end
+
+  def test_unsuccessful_void
+    @gateway.expects(:ssl_request).returns(failed_void_response)
+
+    assert response = @gateway.void(123)
 
     assert response.test?
+    assert_failure response
+    assert_match(/^Unable to void previous transaction./, response.message.to_s)
   end
 
   def test_successful_refund
     @gateway.expects(:ssl_request).returns(successful_refund_response)
 
-    response = @gateway.void(:trans_id => "123")
+    response = @gateway.void(123)
 
     assert_success response
+    assert response.test?
+    assert_match(/^SUCCESS/, response.message.to_s)
+  end
+
+  def test_unsuccessful_refund
+    @gateway.expects(:ssl_request).returns(failed_refund_response)
+
+    assert response = @gateway.refund(123)
 
     assert response.test?
+    assert_failure response
+    assert_match(/^Unable to refund the previous transaction./, response.message.to_s)
   end
 
   def test_invalid_raw_response
     @gateway.expects(:ssl_request).returns(invalid_json_response)
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
-    
+
     assert_failure response
-    
     assert_match(/^Invalid response received from the Payhub API/, response.message.to_s)
   end
 
-  def test_message_for_response_codes
-    PayHubGateway::RESPONSE_CODE_TRANSLATOR.keys.each do |code|
-       @gateway.expects(:ssl_request).returns(json_response_for_codes(code))
+  def test_invalid_number
+    @gateway.expects(:ssl_request).returns(response_for_error_codes('14'))
 
-      response = @gateway.purchase(@amount, @credit_card, @options)
+    response = @gateway.purchase(@amount, @credit_card, optional_params)
+
+    assert response.test?
+    assert_match(PayHubGateway::STANDARD_ERROR_CODE_MAPPING['14'] ,response.error_code)
+  end
+
+  def test_invalid_expiry_date
+    @gateway.expects(:ssl_request).returns(response_for_error_codes('80'))
+
+    response = @gateway.purchase(@amount, @credit_card, optional_params)
+
+    assert response.test?
+    assert_match(PayHubGateway::STANDARD_ERROR_CODE_MAPPING['80'] ,response.error_code)
+  end
+
+  def test_invalid_cvc
+    @gateway.expects(:ssl_request).returns(response_for_error_codes('82'))
+
+    response = @gateway.purchase(@amount, @credit_card, optional_params)
+
+    assert response.test?
+    assert_match(PayHubGateway::STANDARD_ERROR_CODE_MAPPING['82'] ,response.error_code)
+  end
+
+  def test_expired_card
+    @gateway.expects(:ssl_request).returns(response_for_error_codes('82'))
+
+    response = @gateway.purchase(@amount, @credit_card, optional_params)
+
+    assert response.test?
+    assert_match(PayHubGateway::STANDARD_ERROR_CODE_MAPPING['82'] ,response.error_code)
+  end
+
+  def test_card_declined
+    ['05', '61', '62', '65', '93'].each do |error_code|
+      @gateway.expects(:ssl_request).returns(response_for_error_codes(error_code))
+
+      response = @gateway.purchase(@amount, @credit_card, optional_params)
 
       assert response.test?
-
-      assert_match(PayHubGateway::RESPONSE_CODE_TRANSLATOR[code] ,response.message)
+      assert_match(PayHubGateway::STANDARD_ERROR_CODE_MAPPING[error_code] ,response.error_code)
     end
   end
 
-  def test_response_for_avs_codes
-    PayHubGateway::AVS_CODE_TRANSLATOR.keys.each do |code|
-       @gateway.expects(:ssl_request).returns(json_response_for_avs_codes(code))
+  def test_call_issuer
+    ['01', '02'].each do |error_code|
+      @gateway.expects(:ssl_request).returns(response_for_error_codes(error_code))
 
-      response = @gateway.purchase(@amount, @credit_card, @options)
+      response = @gateway.purchase(@amount, @credit_card, optional_params)
 
       assert response.test?
+      assert_match(PayHubGateway::STANDARD_ERROR_CODE_MAPPING[error_code] ,response.error_code)
+    end
+  end
 
+  def test_pickup_card
+    ['04', '07', '41', '43'].each do |error_code|
+      @gateway.expects(:ssl_request).returns(response_for_error_codes(error_code))
+
+      response = @gateway.purchase(@amount, @credit_card, optional_params)
+
+      assert response.test?
+      assert_match(PayHubGateway::STANDARD_ERROR_CODE_MAPPING[error_code] ,response.error_code)
+    end
+  end
+
+  def test_avs_codes
+    PayHubGateway::AVS_CODE_TRANSLATOR.keys.each do |code|
+      @gateway.expects(:ssl_request).returns(response_for_avs_codes(code))
+
+      response = @gateway.purchase(@amount, @credit_card, optional_params)
+
+      assert response.test?
       assert_match(code ,response.avs_result['code'])
     end
   end
 
-  def test_response_for_cvv_codes
+  def test_cvv_codes
     PayHubGateway::CVV_CODE_TRANSLATOR.keys.each do |code|
-       @gateway.expects(:ssl_request).returns(json_response_for_cvv_codes(code))
+      @gateway.expects(:ssl_request).returns(response_for_cvv_codes(code))
 
-      response = @gateway.purchase(@amount, @credit_card, @options)
+      response = @gateway.purchase(@amount, @credit_card, optional_params)
 
       assert response.test?
-
       assert_match(code ,response.cvv_result['code'])
-      
       assert_match(PayHubGateway::CVV_CODE_TRANSLATOR[code] ,response.cvv_result['message'])
     end
   end
 
-  def test_unsuccessful_void
-    @gateway.expects(:ssl_request).returns(json_response_for_unsuccessful_void)
+  def test_unsuccessful_request
+    @gateway.expects(:ssl_request).returns(failed_purchase_or_authorize_response)
 
-    assert response = @gateway.void(:trans_id => 123)
+    @gateway.options.merge!({:mode => 'live', :test => false})
 
-    assert response.test?
-
-    assert_failure response
-    
-    assert_match(/^Unable to void previous transaction./, response.message.to_s)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert !response.success?
+    assert !response.test?
   end
 
-  def test_unsuccessful_refund
-    @gateway.expects(:ssl_request).returns(json_response_for_unsuccessful_refund)
+  def test_unsuccessful_authorize
+    @gateway.expects(:ssl_request).returns(failed_purchase_or_authorize_response)
 
-    assert response = @gateway.refund(:trans_id => 123)
+    @gateway.options.merge!({:mode => 'live', :test => false})
 
-    assert response.test?
-
-    assert_failure response
-
-    assert_match(/^Unable to refund the previous transaction./, response.message.to_s)
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert !response.success?
+    assert !response.test?
   end
 
   private
 
-  def json_response_for_unsuccessful_void
+  def failed_void_response
     <<-RESPONSE
     {
     "CARD_TOKEN_NO": "9999000000001705",
@@ -170,7 +230,7 @@ class PayHubTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def json_response_for_unsuccessful_refund
+  def failed_refund_response
     <<-RESPONSE
     {
     "CARD_TOKEN_NO": "",
@@ -190,7 +250,7 @@ class PayHubTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def json_response_for_cvv_codes(code)
+  def response_for_cvv_codes(code)
     <<-RESPONSE
     {
     "RESPONSE_CODE": "00",
@@ -200,7 +260,7 @@ class PayHubTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def json_response_for_avs_codes(code)
+  def response_for_avs_codes(code)
     <<-RESPONSE
     {
     "RESPONSE_CODE": "00",
@@ -210,16 +270,16 @@ class PayHubTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def json_response_for_codes(response_code)
+  def response_for_error_codes(error_code)
     <<-RESPONSE
     {
-    "RESPONSE_CODE": "#{response_code}",
-    "RESPONSE_TEXT": "#{PayHubGateway::RESPONSE_CODE_TRANSLATOR[response_code]}"
+    "RESPONSE_CODE": "#{error_code}",
+    "RESPONSE_TEXT": "#{PayHubGateway::STANDARD_ERROR_CODE_MAPPING[error_code]}"
     }
     RESPONSE
   end
 
-  def successful_purchase_response
+  def successful_purchase_or_authorize_response
     <<-RESPONSE
     {
     "CARD_TOKEN_NO": "9999000000001033",
@@ -239,16 +299,16 @@ class PayHubTest < Test::Unit::TestCase
     RESPONSE
   end
 
-  def failed_purchase_response
+  def failed_purchase_or_authorize_response
     <<-RESPONSE
     {
     "CARD_TOKEN_NO": "",
     "AVS_RESULT_CODE": "",
     "TRANSACTION_ID": "",
-    "CUSTOMER_ID": "", 
+    "CUSTOMER_ID": "",
     "VERIFICATION_RESULT_CODE": "",
     "RESPONSE_CODE": "4008",
-    "RISK_STATUS_RESPONSE_CODE": "", 
+    "RISK_STATUS_RESPONSE_CODE": "",
     "TRANSACTION_DATE_TIME": "",
     "RISK_STATUS_RESPONSE_TEXT"=>"",
     "APPROVAL_CODE"=>"",
@@ -273,7 +333,7 @@ class PayHubTest < Test::Unit::TestCase
     "RISK_STATUS_RESPONSE_TEXT": "",
     "APPROVAL_CODE": "TAS444",
     "BATCH_ID": "416",
-    "RESPONSE_TEXT": "SUCCESS", 
+    "RESPONSE_TEXT": "SUCCESS",
     "CIS_NOTE": ""
     }
     RESPONSE
@@ -293,8 +353,27 @@ class PayHubTest < Test::Unit::TestCase
     "RISK_STATUS_RESPONSE_TEXT": "",
     "APPROVAL_CODE": "      ",
     "BATCH_ID": "417",
-    "RESPONSE_TEXT": "SUCCESS", 
+    "RESPONSE_TEXT": "SUCCESS",
     "CIS_NOTE": ""
+    }
+    RESPONSE
+  end
+
+  def successful_capture_response
+    <<-RESPONSE
+    {
+    "BATCH_ID": "428",
+    "RESPONSE_TEXT": "TRANSACTION CAPTURED SUCCESSFULLY",
+    "RESPONSE_CODE": "00"
+    }
+    RESPONSE
+  end
+
+  def failed_capture_response
+    <<-RESPONSE
+    {
+    "RESPONSE_TEXT": "UNABLE TO CAPTURE",
+    "RESPONSE_CODE": "4075"
     }
     RESPONSE
   end
@@ -303,5 +382,41 @@ class PayHubTest < Test::Unit::TestCase
     <<-RESPONSE
     "foo" =>  "bar"
     RESPONSE
+  end
+
+  def add_credentials
+    {
+      :orgid => "123456",
+      :username => "abc123DEF",
+      :password => "abc123DEF",
+      :tid => '123'
+    }
+  end
+
+  def credit_card_params
+    {
+      :first_name => 'Bob',
+      :last_name => 'Bobsen',
+      :month => '06',
+      :year => '2020',
+      :verification_value => '9997'
+    }
+  end
+
+  def optional_params
+    {
+      :first_name => 'Garry',
+      :last_name => 'Barry',
+      :phone => '9179328589',
+      :email => 'abcsss@mailinator.com',
+      :address =>
+      {
+        :address1 => '123 ahappy St.',
+        :address2 => 'Abca',
+        :city => 'aHappy City',
+        :state => 'CA',
+        :zip => '94901'
+      }
+    }
   end
 end


### PR DESCRIPTION
@j-mutter  @shopify-admins @shopify-deployer @shopify-hooks 
Have added support for Pay Hub Payment gateway. http://www.payhub.com/
Currently it only supports purchase, void and refund transactions. Please take a look and let me know if I missed anything. 

Thanks