### PR TITLE
Add void_release method to usaepay transaction gateway.

### DIFF
--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -15,7 +15,8 @@ module ActiveMerchant #:nodoc:
         :purchase       => 'cc:sale',
         :capture        => 'cc:capture',
         :refund         => 'cc:refund',
-        :void           => 'cc:void'
+        :void           => 'cc:void',
+        :void_release   => 'cc:void:release'
       }
 
       STANDARD_ERROR_CODE_MAPPING = {
@@ -95,7 +96,8 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options = {})
         post = { :refNum => authorization }
-        commit(:void, post)
+        command = options.delete(:void_mode) || :void
+        commit(command, post)
       end
 
     private
@@ -245,6 +247,9 @@ module ActiveMerchant #:nodoc:
         parameters[:key]      = @options[:login]
         parameters[:software] = 'Active Merchant'
         parameters[:testmode] = (@options[:test] ? 1 : 0)
+        seed = SecureRandom.hex(32).upcase
+        hash = Digest::SHA1.hexdigest("#{parameters[:command]}:#{@options[:password]}:#{parameters[:amount]}:#{parameters[:invoice]}:#{seed}")
+        parameters[:hash] = "s/#{seed}/#{hash}/n"
 
         parameters.collect { |key, value| "UM#{key}=#{CGI.escape(value.to_s)}" }.join("&")
       end

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -89,6 +89,20 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     assert_match(/Unable to locate transaction/, void.message)
   end
 
+  def test_successful_void_release
+    assert response = @gateway.purchase(@amount, @creditcard, @options)
+    assert_success response
+    assert response.authorization
+    assert void = @gateway.void(response.authorization, void_mode: :void_release)
+    assert_success void
+  end
+
+  def test_unsuccessful_void_release
+    assert void = @gateway.void("unknown_authorization", void_mode: :void_release)
+    assert_failure void
+    assert_match(/Unable to locate transaction/, void.message)
+  end
+
   def test_invalid_key
     gateway = UsaEpayTransactionGateway.new(:login => '')
     assert response = gateway.purchase(@amount, @creditcard, @options)

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -22,14 +22,14 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
   def test_request_url_live
     gateway = UsaEpayTransactionGateway.new(:login => 'LOGIN', :test => false)
     gateway.expects(:ssl_post).
-      with('https://www.usaepay.com/gate', purchase_request).
+      with('https://www.usaepay.com/gate', regexp_matches(Regexp.new('^' + Regexp.escape(purchase_request)))).
       returns(successful_purchase_response)
     gateway.purchase(@amount, @credit_card, @options)
   end
 
   def test_request_url_test
     @gateway.expects(:ssl_post).
-      with('https://sandbox.usaepay.com/gate', purchase_request).
+      with('https://sandbox.usaepay.com/gate', regexp_matches(Regexp.new('^' + Regexp.escape(purchase_request)))).
       returns(successful_purchase_response)
     @gateway.purchase(@amount, @credit_card, @options)
   end


### PR DESCRIPTION
Also adds a security hash to usaepay transaction gateway api requests.

The void:release method indicates to USAEpay that when the transaction is voided it should immediately send an instruction to the institution to release the funds. With a plain void, the instruction is not sent until the batch closes.
