### PR TITLE
Null gateway

### DIFF
--- a/lib/active_merchant/billing/base.rb
+++ b/lib/active_merchant/billing/base.rb
@@ -32,7 +32,8 @@ module ActiveMerchant #:nodoc:
       self.mode = :production
 
       # Return the matching gateway for the provider
-      # * <tt>bogus</tt>: BogusGateway - Does nothing (for testing)
+      # * <tt>null</tt>: NullGateway - Does nothing (for testing)
+      # * <tt>bogus</tt>: BogusGateway - Does almost nothing (for testing)
       # * <tt>moneris</tt>: MonerisGateway
       # * <tt>authorize_net</tt>: AuthorizeNetGateway
       # * <tt>trust_commerce</tt>: TrustCommerceGateway
@@ -52,7 +53,8 @@ module ActiveMerchant #:nodoc:
 
       # Return the matching integration module
       # You can then get the notification from the module
-      # * <tt>bogus</tt>: Bogus - Does nothing (for testing)
+      # * <tt>null</tt>: NullGateway - Does nothing (for testing)
+      # * <tt>bogus</tt>: BogusGateway - Does almost nothing (for testing)
       # * <tt>chronopay</tt>: Chronopay
       # * <tt>paypal</tt>: Paypal
       #

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -22,7 +22,7 @@ module ActiveMerchant #:nodoc:
     # * Forbrugsforeningen
     # * Laser
     #
-    # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
+    # For testing purposes, use the 'null' or 'bogus' credit card brands. They skips the majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
     # with the details of particular credit cards or your gateway.
     #
@@ -88,7 +88,7 @@ module ActiveMerchant #:nodoc:
       # * +'forbrugsforeningen'+
       # * +'laser'+
       #
-      # Or, if you wish to test your implementation, +'bogus'+.
+      # Or, if you wish to test your implementation, +'null'+ or +'bogus'+.
       #
       # @return (String) the credit card brand
       def brand
@@ -229,8 +229,8 @@ module ActiveMerchant #:nodoc:
       def validate
         errors = validate_essential_attributes + validate_verification_value
 
-        # Bogus card is pretty much for testing purposes. Lets just skip these extra tests if its used
-        return errors_hash(errors) if brand == 'bogus'
+        # Null and Bogus cards are pretty much for testing purposes. Lets just skip these extra tests if used
+        return errors_hash(errors) if brand == 'null' || brand == 'bogus'
 
         errors_hash(
           errors +

--- a/lib/active_merchant/billing/gateways/null.rb
+++ b/lib/active_merchant/billing/gateways/null.rb
@@ -1,0 +1,57 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # Null Gateway
+    class NullGateway < Gateway
+      AUTHORIZATION = '00000'
+
+      SUCCESS_MESSAGE = "Null Gateway: Forced success"
+
+      self.supported_countries = []
+      self.supported_cardtypes = [:null]
+      self.homepage_url = 'http://example.com'
+      self.display_name = 'Null'
+
+      def authorize(money, paysource, options = {})
+        money = amount(money)
+        Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION )
+      end
+
+      def purchase(money, paysource, options = {})
+        Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true, :authorization => AUTHORIZATION)
+      end
+
+      def credit(money, paysource, options = {})
+        if paysource.is_a?(String)
+          ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
+          return refund(money, paysource, options)
+        end
+
+        money = amount(money)
+        Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true )
+      end
+
+      def refund(money, reference, options = {})
+        money = amount(money)
+        Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+      end
+
+      def capture(money, reference, options = {})
+        money = amount(money)
+        Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+      end
+
+      def void(reference, options = {})
+        Response.new(true, SUCCESS_MESSAGE, {:authorization => reference}, :test => true)
+      end
+
+      def store(paysource, options = {})
+        Response.new(true, SUCCESS_MESSAGE, {:billingid => '1'}, :test => true, :authorization => AUTHORIZATION)
+      end
+
+      def unstore(reference, options = {})
+        Response.new(true, SUCCESS_MESSAGE, {}, :test => true)
+      end
+
+    end
+  end
+end

--- a/lib/support/gateway_support.rb
+++ b/lib/support/gateway_support.rb
@@ -21,6 +21,7 @@ class GatewaySupport #:nodoc:
       end
     end
     @gateways = Gateway.implementations.sort_by(&:name)
+    @gateways.delete(ActiveMerchant::Billing::NullGateway)
     @gateways.delete(ActiveMerchant::Billing::BogusGateway)
   end
 

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -10,6 +10,7 @@ class BaseTest < Test::Unit::TestCase
   end
 
   def test_should_return_a_new_gateway_specified_by_symbol_name
+    assert_equal NullGateway,          Base.gateway(:null)
     assert_equal BogusGateway,         Base.gateway(:bogus)
     assert_equal MonerisGateway,       Base.gateway(:moneris)
     assert_equal MonerisUsGateway,     Base.gateway(:moneris_us)

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -43,8 +43,11 @@ class CreditCardTest < Test::Unit::TestCase
     assert_not_valid @visa
   end
 
-  def test_should_be_able_to_liberate_a_bogus_card
-    c = credit_card('', :brand => 'bogus')
+  def test_should_be_able_to_liberate_a_null_or_bogus_card
+    c = credit_card('', :brand => 'null')
+    assert_valid c
+
+    c.brand = 'bogus'
     assert_valid c
 
     c.brand = 'visa'

--- a/test/unit/gateways/null_test.rb
+++ b/test/unit/gateways/null_test.rb
@@ -1,0 +1,95 @@
+require 'test_helper'
+
+class NullTest < Test::Unit::TestCase
+  CC_PLACEHOLDER = "9999888877776666"
+  CHECK_PLACEHOLDER = "99999999999"
+
+  def setup
+    @gateway = NullGateway.new(
+      :login => 'null',
+      :password => 'null'
+    )
+
+    @creditcard = credit_card(CC_PLACEHOLDER)
+
+    @response = ActiveMerchant::Billing::Response.new(true, "Transaction successful", :transid => NullGateway::AUTHORIZATION)
+  end
+
+  def test_authorize
+    assert  @gateway.authorize(1000, credit_card(CC_PLACEHOLDER)).success?
+  end
+
+  def test_purchase
+    assert  @gateway.purchase(1000, credit_card(CC_PLACEHOLDER)).success?
+  end
+
+  def test_capture
+    assert  @gateway.capture(1000, '1337').success?
+    assert  @gateway.capture(1000, @response.params["transid"]).success?
+  end
+
+  def test_credit
+    assert  @gateway.credit(1000, credit_card(CC_PLACEHOLDER)).success?
+  end
+
+  def test_refund
+    assert  @gateway.refund(1000, '1337').success?
+    assert  @gateway.refund(1000, @response.params["transid"]).success?
+  end
+
+  def test_credit_uses_refund
+    options = {:foo => :bar}
+    @gateway.expects(:refund).with(1000, '1337', options)
+    assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE) do
+      @gateway.credit(1000, '1337', options)
+    end
+  end
+
+  def test_void
+    assert  @gateway.void('1337').success?
+    assert  @gateway.void(@response.params["transid"]).success?
+  end
+
+  def test_store
+    assert  @gateway.store(credit_card(CC_PLACEHOLDER)).success?
+  end
+
+  def test_unstore
+    assert @gateway.unstore(CC_PLACEHOLDER).success?
+  end
+
+  def test_store_then_purchase
+    reference = @gateway.store(@creditcard)
+    assert @gateway.purchase(1000, reference.authorization).success?
+  end
+
+  def test_supported_countries
+    assert_equal [], NullGateway.supported_countries
+  end
+
+  def test_supported_card_types
+    assert_equal [:null], NullGateway.supported_cardtypes
+  end
+
+  def test_authorize_with_check
+    assert  @gateway.authorize(1000, check(:account_number => CHECK_PLACEHOLDER, :number => nil)).success?
+  end
+
+  def test_purchase_with_check
+    # use account number if number isn't given
+    assert  @gateway.purchase(1000, check(:account_number => CHECK_PLACEHOLDER, :number => nil)).success?
+  end
+
+  def test_store_with_check
+    assert  @gateway.store(check(:account_number => CHECK_PLACEHOLDER, :number => nil)).success?
+  end
+
+  def test_credit_with_check
+    assert  @gateway.credit(1000, check(:account_number => CHECK_PLACEHOLDER, :number => nil)).success?
+  end
+
+  def test_store_then_purchase_with_check
+    reference = @gateway.store(check(:account_number => CHECK_PLACEHOLDER, :number => nil))
+    assert @gateway.purchase(1000, reference.authorization).success?
+  end
+end


### PR DESCRIPTION
Related with #1489 

A Null object never fails, and returns "safe" values with no side-effects.

In this case I think it was fine returning "real" responses instead of creating a "NullResponse" object, since responses are treated as "data" - they don't change the state of anything by themselves.