### PR TITLE
Fix Exact Gateway test, handle 401 auth failure

### DIFF
--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -168,6 +168,13 @@ module ActiveMerchant #:nodoc:
            :avs_result => { :code => response[:avs] },
            :cvv_result => response[:cvv2]
          )
+
+      rescue ResponseError => e
+        case e.response.code
+        when '401'
+          return Response.new(false, 'Invalid Logon', {}, :test => test?)
+        end
+        raise
       end
 
       def successful?(response)

--- a/test/remote/gateways/remote_exact_test.rb
+++ b/test/remote/gateways/remote_exact_test.rb
@@ -47,7 +47,7 @@ class RemoteExactTest < Test::Unit::TestCase
   def test_failed_capture
     assert response = @gateway.capture(@amount, '')
     assert_failure response
-    assert_match %r{Precondition Failed}i, response.message
+    assert_match %r{Invalid Transaction Tag}i, response.message
   end
 
   def test_invalid_login


### PR DESCRIPTION
Fixes test failure:
RemoteExactTest#test_failed_capture, by testing for correct response string

And test error:
RemoteExactTest#test_invalid_login, by properly handling 401
