### PR TITLE
SagePay: make `VPSProtocol` user-configurable

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -5,12 +5,10 @@ module ActiveMerchant #:nodoc:
       self.simulate = false
 
       class_attribute :simulator_url
-      class_attribute :protocol_version
 
       self.test_url = 'https://test.sagepay.com/gateway/service'
       self.live_url = 'https://live.sagepay.com/gateway/service'
       self.simulator_url = 'https://test.sagepay.com/Simulator'
-      self.protocol_version = '3.00'
 
       APPROVED = 'OK'
 
@@ -356,7 +354,7 @@ module ActiveMerchant #:nodoc:
         parameters.update(
           :Vendor => @options[:login],
           :TxType => TRANSACTIONS[action],
-          :VPSProtocol => protocol_version
+          :VPSProtocol => @options.fetch(:protocol_version, '3.00')
         )
 
         if(application_id && (application_id != Gateway.application_id))

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -5,10 +5,12 @@ module ActiveMerchant #:nodoc:
       self.simulate = false
 
       class_attribute :simulator_url
+      class_attribute :protocol_version
 
       self.test_url = 'https://test.sagepay.com/gateway/service'
       self.live_url = 'https://live.sagepay.com/gateway/service'
       self.simulator_url = 'https://test.sagepay.com/Simulator'
+      self.protocol_version = '3.00'
 
       APPROVED = 'OK'
 
@@ -354,7 +356,7 @@ module ActiveMerchant #:nodoc:
         parameters.update(
           :Vendor => @options[:login],
           :TxType => TRANSACTIONS[action],
-          :VPSProtocol => "3.00"
+          :VPSProtocol => protocol_version
         )
 
         if(application_id && (application_id != Gateway.application_id))

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -3,10 +3,12 @@ require 'test_helper'
 class SagePayTest < Test::Unit::TestCase
   include CommStub
 
+  def create_gateway(opts = {})
+    SagePayGateway.new(opts.merge(:login => 'X'))
+  end
+
   def setup
-    @gateway = SagePayGateway.new(
-      :login => 'X'
-    )
+    @gateway = create_gateway
 
     @credit_card = credit_card('4242424242424242', :brand => 'visa')
     @options = {
@@ -158,7 +160,7 @@ class SagePayTest < Test::Unit::TestCase
   end
 
   def test_protocol_version_is_honoured
-    ActiveMerchant::Billing::SagePayGateway.protocol_version = '2.23'
+    @gateway = create_gateway(:protocol_version => '2.23')
 
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -157,6 +157,16 @@ class SagePayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_protocol_version_is_honoured
+    ActiveMerchant::Billing::SagePayGateway.protocol_version = '2.23'
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/VPSProtocol=2.23/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_referrer_id_is_added_to_post_data_parameters
     ActiveMerchant::Billing::SagePayGateway.application_id = '00000000-0000-0000-0000-000000000001'
     stub_comms(@gateway, :ssl_request) do


### PR DESCRIPTION
This makes the `VPSProtocol` parameter in the SagePay gateway configurable like so:

```ruby
ActiveMerchant::Billing::SagePayGateway.protocol_version = '2.23'
```

This is desirable due to the fact that SagePay do not intend to update the simulator to support the latest protocol, but getting live & test accounts can be a lengthy / difficult process.

So it's helpful to be able to build against "something" while you're waiting.

Have at it! :sparkling_heart: