### PR TITLE
Add PCI Compliant Repeat Billing and Cardholder Information storage for ...

### DIFF
--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -1,5 +1,15 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
+    # To perform PCI Compliant Repeat Billing
+    #
+    #   Ensure that PCI Compliant Repeat Billing is enabled on your merchant account:
+    #    "Enable PCI Compliant Repeat Billing, Up-selling and Cross-selling" in Step 6 of the Credit Cards setup page
+    #
+    #  Instead of passing a credit_card to authorize or purchase, pass the transaction id (res.authorization)
+    #  of a past Netbilling transaction
+    #
+    # To store billing information without performing an operation, use the 'store' method
+    # which invokes the tran_type 'Q' (Quasi) operation and returns a transaction id to use in future Repeat Billing operations
     class NetbillingGateway < Gateway
       self.live_url = self.test_url = 'https://secure.netbilling.com:1402/gw/sas/direct3.1'
 
@@ -9,7 +19,8 @@ module ActiveMerchant #:nodoc:
         :refund        => 'R',
         :credit        => 'C',
         :capture       => 'D',
-        :void          => 'U'
+        :void          => 'U',
+        :quasi         => 'Q'
       }
 
       SUCCESS_CODES = [ '1', 'T' ]
@@ -27,23 +38,23 @@ module ActiveMerchant #:nodoc:
         super
       end
 
-      def authorize(money, credit_card, options = {})
+      def authorize(money, credit_card_or_transaction_id, options = {})
         post = {}
         add_amount(post, money)
         add_invoice(post, options)
-        add_credit_card(post, credit_card)
-        add_address(post, credit_card, options)
+        add_payment_source(post, credit_card_or_transaction_id)
+        add_address(post, credit_card_or_transaction_id, options)
         add_customer_data(post, options)
 
         commit(:authorization, post)
       end
 
-      def purchase(money, credit_card, options = {})
+      def purchase(money, credit_card_or_transaction_id, options = {})
         post = {}
         add_amount(post, money)
         add_invoice(post, options)
-        add_credit_card(post, credit_card)
-        add_address(post, credit_card, options)
+        add_payment_source(post, credit_card_or_transaction_id)
+        add_address(post, credit_card_or_transaction_id, options)
         add_customer_data(post, options)
 
         commit(:purchase, post)
@@ -77,6 +88,16 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_reference(post, source)
         commit(:void, post)
+      end
+
+      def store(credit_card, options = {})
+        post = {}
+        add_amount(post, 0)
+        add_payment_source(post, credit_card)
+        add_address(post, credit_card, options)
+        add_customer_data(post, options)
+
+        commit(:quasi, post)
       end
 
       def test?
@@ -123,6 +144,18 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, options)
         post[:description] = options[:description]
+      end
+
+      def add_payment_source(params, source)
+        if source.is_a?(String)
+          add_transaction_id(params, source)
+        else
+          add_credit_card(params, source)
+        end
+      end
+
+      def add_transaction_id(post, transaction_id)
+        post[:card_number] = 'CS:' + transaction_id
       end
 
       def add_credit_card(post, credit_card)

--- a/test/unit/gateways/netbilling_test.rb
+++ b/test/unit/gateways/netbilling_test.rb
@@ -64,6 +64,51 @@ class NetbillingTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_repeat_purchase
+    @gateway.expects(:ssl_post).returns(successful_repeat_purchase_response)
+
+    assert response = @gateway.purchase(@amount, '112281536850', @options)
+    assert_success response
+    assert_equal '112232503575', response.authorization
+    assert response.test?
+  end
+
+  def test_unsuccessful_repeat_purchase_invalid_trans_id
+    http_response = mock()
+    http_response.stubs(:code).returns('611')
+    http_response.stubs(:body).returns('')
+    http_response.stubs(:message).returns(unsuccessful_repeat_purchase_invalid_trans_id_response)
+    response_error = ::ActiveMerchant::ResponseError.new(http_response)
+    @gateway.expects(:ssl_post).raises(response_error)
+
+    assert response = @gateway.purchase(@amount, '1111', @options)
+    assert_failure response
+    assert_match(/no record found/i, response.message)
+    assert response.test?
+  end
+
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+
+    assert response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert response.test?
+  end
+
+  def test_unsuccessful_store_invalid_billing_info
+    http_response = mock()
+    http_response.stubs(:code).returns('699')
+    http_response.stubs(:body).returns('')
+    http_response.stubs(:message).returns(unsuccessful_store_invalid_billing_info_response)
+    response_error = ::ActiveMerchant::ResponseError.new(http_response)
+    @gateway.expects(:ssl_post).raises(response_error)
+
+    assert response = @gateway.store(@credit_card, @options)
+    assert_failure response
+    assert_match(/invalid credit card number/i, response.message)
+    assert response.test?
+  end
+
   private
   def successful_purchase_response
     "avs_code=X&cvv2_code=M&status_code=1&auth_code=999999&trans_id=110270311543&auth_msg=TEST+APPROVED&auth_date=2008-01-25+16:43:54"
@@ -71,5 +116,21 @@ class NetbillingTest < Test::Unit::TestCase
   
   def unsuccessful_purchase_response
     "status_code=0&auth_msg=CARD+EXPIRED&trans_id=110492608613&auth_date=2008-01-25+17:47:44"
+  end
+
+  def successful_repeat_purchase_response
+    "avs_code=X&cvv2_code=M&status_code=1&processor=TEST&auth_code=999999&settle_amount=1.00&settle_currency=USD&trans_id=112232503575&auth_msg=TEST+APPROVED&auth_date=2014-12-29+18:23:40"
+  end
+
+  def unsuccessful_repeat_purchase_invalid_trans_id_response
+    "No Record Found For Specified ID"
+  end
+
+  def successful_store_response
+    "status_code=T&processor=TEST&settle_amount=0.00&settle_currency=USD&trans_id=112235386882&auth_msg=OFFLINE+RECORD&auth_date=2014-12-29+18:23:43"
+  end
+
+  def unsuccessful_store_invalid_billing_info_response
+    "20111: Invalid credit card number: 123"
   end
 end


### PR DESCRIPTION
From Netbilling documentation:

  This feature enables you to perform a future repeat-billing or up-sell for the same consumer within the same gateway account, rather than storing and specifying the card number and billing address again. Simply check
  "Enable PCI Compliant Repeat Billing, Up-selling and Cross-selling" in Step 6 of the Credit Cards setup page. When the feature is enabled, you would send "CS:123456789012" as the card_number, where 123456789012 is
  the trans_id of the original transaction.

Per above, netbilling.rb has been modified to accept a string ("123456789012") in lieu of a credit_card for submission.

Furthermore, Netbilling Direct Mode also supports submission of billing information to PCI compliant storage without performing any credit gateway operations with the 'Quasi' (tran_type 'Q') mode. This is implemented in the 'store' method.