### PR TITLE
Fix duplicate hash key in braintree blue gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -431,8 +431,7 @@ module ActiveMerchant #:nodoc:
               "token" => cc.token,
               "last_4" => cc.last_4,
               "card_type" => cc.card_type,
-              "masked_number" => cc.masked_number,
-              "token" => cc.token
+              "masked_number" => cc.masked_number
             }
           end
         end


### PR DESCRIPTION
This was producing a warning when running on 2.2