### PR TITLE
Add FirstData E4 Support for Multiple Mastercard String Formats

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -264,7 +264,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(successful?(response), message_from(response), response,
           :test => test?,
-          :authorization => response_authorization(action, response, credit_card),
+          :authorization => successful?(response) ? response_authorization(action, response, credit_card) : nil,
           :avs_result => {:code => response[:avs]},
           :cvv_result => response[:cvv2]
         )

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -264,7 +264,7 @@ module ActiveMerchant #:nodoc:
 
         Response.new(successful?(response), message_from(response), response,
           :test => test?,
-          :authorization => successful?(response) ? response_authorization(action, response, credit_card) : nil,
+          :authorization => successful?(response) ? response_authorization(action, response, credit_card) : '',
           :avs_result => {:code => response[:avs]},
           :cvv_result => response[:cvv2]
         )

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -27,11 +27,12 @@ module ActiveMerchant #:nodoc:
       BRANDS = {
         :visa => 'Visa',
         :master => "Mastercard",
-        :mastercard => "Mastercard",
         :american_express => "American Express",
         :jcb => "JCB",
         :discover => "Discover"
       }
+
+      E4_BRANDS = BRANDS.merge({:mastercard => "Mastercard"})
 
       self.supported_cardtypes = BRANDS.keys
       self.supported_countries = ["CA", "US"]
@@ -251,7 +252,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def card_type(credit_card_brand)
-        BRANDS[credit_card_brand.to_sym] if credit_card_brand
+        E4_BRANDS[credit_card_brand.to_sym] if credit_card_brand
       end
 
       def commit(action, request, credit_card = nil)

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -27,6 +27,7 @@ module ActiveMerchant #:nodoc:
       BRANDS = {
         :visa => 'Visa',
         :master => "Mastercard",
+        :mastercard => "Mastercard",
         :american_express => "American Express",
         :jcb => "JCB",
         :discover => "Discover"

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -25,6 +25,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, {})
     assert_failure response
     assert response.test?
+    assert_equal '', response.authorization
     assert_equal 'Unauthorized Request. Bad or missing credentials.', response.message
   end
 

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -108,7 +108,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_supported_cardtypes
-    assert_equal [:visa, :master, :mastercard, :american_express, :jcb, :discover], FirstdataE4Gateway.supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :jcb, :discover], FirstdataE4Gateway.supported_cardtypes
   end
 
   def test_avs_result

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -32,7 +32,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert response.test?
     assert_equal 'Transaction Normal - Approved', response.message
 
-    ExactGateway::SENSITIVE_FIELDS.each{|f| assert !response.params.has_key?(f.to_s)}
+    FirstdataE4Gateway::SENSITIVE_FIELDS.each{|f| assert !response.params.has_key?(f.to_s)}
   end
 
   def test_successful_purchase_with_token
@@ -99,7 +99,8 @@ class FirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal ['CA', 'US'], ExactGateway.supported_countries
+    assert_equal ['CA', 'US'], FirstdataE4Gateway.supported_countries
+  end
   end
 
   def test_avs_result

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -20,6 +20,14 @@ class FirstdataE4Test < Test::Unit::TestCase
     @authorization = "ET1700;106625152;4738"
   end
 
+  def test_invalid_credentials
+    @gateway.expects(:ssl_post).raises(bad_credentials_response)
+    assert response = @gateway.store(@credit_card, {})
+    assert_failure response
+    assert response.test?
+    assert_equal 'Unauthorized Request. Bad or missing credentials.', response.message
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -630,6 +638,43 @@ response: !ruby/object:Net::HTTPBadRequest
   http_version: "1.1"
   message: Bad Request
   read: true
+  socket:
+    RESPONSE
+    YAML.load(yamlexcep)
+  end
+
+  def bad_credentials_response
+    yamlexcep = <<-RESPONSE
+--- !ruby/exception:ActiveMerchant::ResponseError
+message:
+response: !ruby/object:Net::HTTPUnauthorized
+  code: '401'
+  message: Authorization Required
+  body: Unauthorized Request. Bad or missing credentials.
+  read: true
+  header:
+    cache-control:
+    - no-cache
+    content-type:
+    - text/html; charset=utf-8
+    date:
+    - Tue, 30 Dec 2014 23:28:32 GMT
+    server:
+    - Apache
+    status:
+    - '401'
+    x-rack-cache:
+    - invalidate, pass
+    x-request-id:
+    - 4157e21cc5620a95ead8d2025b55bdf4
+    x-ua-compatible:
+    - IE=Edge,chrome=1
+    content-length:
+    - '49'
+    connection:
+    - Close
+  body_exist: true
+  http_version: '1.1'
   socket:
     RESPONSE
     YAML.load(yamlexcep)

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -102,10 +102,6 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert_equal ['CA', 'US'], ExactGateway.supported_countries
   end
 
-  def test_supported_card_types
-    assert_equal [:visa, :master, :american_express, :jcb, :discover], ExactGateway.supported_cardtypes
-  end
-
   def test_avs_result
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -20,10 +20,6 @@ class FirstdataE4Test < Test::Unit::TestCase
     @authorization = "ET1700;106625152;4738"
   end
 
-  def test_supported_cardtypes
-    assert_equal [:visa, :master, :american_express, :jcb, :discover], FirstdataE4Gateway.supported_cardtypes
-  end
-
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -101,6 +97,9 @@ class FirstdataE4Test < Test::Unit::TestCase
   def test_supported_countries
     assert_equal ['CA', 'US'], FirstdataE4Gateway.supported_countries
   end
+
+  def test_supported_cardtypes
+    assert_equal [:visa, :master, :mastercard, :american_express, :jcb, :discover], FirstdataE4Gateway.supported_cardtypes
   end
 
   def test_avs_result
@@ -145,6 +144,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   def test_card_type
     assert_equal 'Visa', @gateway.send(:card_type, 'visa')
     assert_equal 'Mastercard', @gateway.send(:card_type, 'master')
+    assert_equal 'Mastercard', @gateway.send(:card_type, 'mastercard')
     assert_equal 'American Express', @gateway.send(:card_type, 'american_express')
     assert_equal 'JCB', @gateway.send(:card_type, 'jcb')
     assert_equal 'Discover', @gateway.send(:card_type, 'discover')


### PR DESCRIPTION
The response back from FirstData uses the string 'mastercard'. When using the FirstData Response to reconstruct the credit card info, it needs this key in the BRANDS constant to convert to a valid card.