### PR TITLE
Prevent multiple trackids from being passed to Checkout

### DIFF
--- a/test/remote/gateways/remote_checkout_test.rb
+++ b/test/remote/gateways/remote_checkout_test.rb
@@ -65,7 +65,7 @@ class RemoteCheckoutTest < Test::Unit::TestCase
     auth = @gateway.authorize(100, @credit_card, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(100, auth.authorization.split('|')[0], @options)
+    assert capture = @gateway.capture(100, auth.authorization, @options.merge(is_reference: true))
     assert_success capture
     assert_equal 'Successful', capture.message
   end

--- a/test/unit/gateways/checkout_test.rb
+++ b/test/unit/gateways/checkout_test.rb
@@ -81,9 +81,15 @@ class CheckoutTest < Test::Unit::TestCase
   end
 
   def test_successful_void
-    @gateway.expects(:ssl_post).returns(successful_void_response)
+    @options['orderid'] = '9c38d0506da258e216fa072197faaf37'
+    void = stub_comms(@gateway, :ssl_request) do
+      @gateway.void('36919371|9c38d0506da258e216fa072197faaf37|1|CAD|100', @options)
+    end.check_request do |method, endpoint, data, headers|
+      # Should only be one pair of track id tags.
+      assert_equal 2, data.scan(/trackid/).count
+    end.respond_with(successful_void_response)
 
-    assert void = @gateway.void('36919371|9c38d0506da258e216fa072197faaf37|1|CAD|100', @options)
+    assert void
     assert_success void
 
     assert_equal 'Successful', void.message


### PR DESCRIPTION
The trackid is used as a reference value and can also be passed in as an
orderid. The xml builder does not hash these values so it can end up
being added twice.  This patch honors the reference value first since it
is used to maintain the transaction reference.