### PR TITLE
Fixes tests with new 2016 expiration dates

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -151,11 +151,15 @@ module ActiveMerchant
     DEFAULT_CREDENTIALS = File.join(File.dirname(__FILE__), 'fixtures.yml') unless defined?(DEFAULT_CREDENTIALS)
 
     private
+    def default_expiration_date
+      @default_expiration_date ||= Date.new((Time.now.year + 1), 9, 30)
+    end
+
     def credit_card(number = '4242424242424242', options = {})
       defaults = {
         :number => number,
-        :month => 9,
-        :year => Time.now.year + 1,
+        :month => default_expiration_date.month,
+        :year => default_expiration_date.year,
         :first_name => 'Longbob',
         :last_name => 'Longsen',
         :verification_value => '123',

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -69,7 +69,7 @@ class Cashnet < Test::Unit::TestCase
     @gateway.send(:add_creditcard, result, @credit_card)
     assert_equal @credit_card.number, result[:cardno]
     assert_equal @credit_card.verification_value, result[:cid]
-    assert_equal '0915', result[:expdate]
+    assert_equal expected_expiration_date, result[:expdate]
     assert_equal 'Longbob Longsen', result[:card_name_g]
   end
 
@@ -115,6 +115,9 @@ class Cashnet < Test::Unit::TestCase
   end
 
   private
+  def expected_expiration_date
+    '%02d%02d' % [@credit_card.month, @credit_card.year.to_s[2..4]]
+  end
 
   def minimum_requirements
     %w(command merchant operator station password amount custcode itemcode)

--- a/test/unit/gateways/quickpay_test.rb
+++ b/test/unit/gateways/quickpay_test.rb
@@ -13,19 +13,19 @@ class QuickpayTest < Test::Unit::TestCase
     @amount = 100
     @options = { :order_id => '1', :billing_address => address }
   end
-  
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_authorization_response, successful_capture_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal '2865261', response.authorization
     assert response.test?
   end
-  
+
   def test_successful_authorization
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
-    
+
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_equal '2865261', response.authorization
@@ -38,6 +38,7 @@ class QuickpayTest < Test::Unit::TestCase
       :password => 'PASSWORD',
       :version => 6
     )
+    @gateway.expects(:generate_check_hash).returns(mock_md5_hash)
 
     response = stub_comms do
       @gateway.store(@credit_card, {:order_id => 'fa73664073e23597bbdd', :description => 'Storing Card'})
@@ -52,6 +53,8 @@ class QuickpayTest < Test::Unit::TestCase
   end
 
   def test_successful_store_for_v7
+    @gateway.expects(:generate_check_hash).returns(mock_md5_hash)
+
     response = stub_comms do
       @gateway.store(@credit_card, {:order_id => 'ed7546cb4ceb8f017ea4', :description => 'Storing Card'})
     end.check_request do |endpoint, data, headers|
@@ -66,39 +69,39 @@ class QuickpayTest < Test::Unit::TestCase
 
   def test_failed_authorization
     @gateway.expects(:ssl_post).returns(failed_authorization_response)
-    
+
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Missing/error in card verification data', response.message
     assert response.test?
   end
-  
+
   def test_parsing_response_with_errors
     @gateway.expects(:ssl_post).returns(error_response)
-    
+
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal '008', response.params['qpstat']
     assert_equal 'Missing/error in cardnumber, Missing/error in expirationdate, Missing/error in card verification data, Missing/error in amount, Missing/error in ordernum, Missing/error in currency', response.params['qpstatmsg']
     assert_equal 'Missing/error in cardnumber, Missing/error in expirationdate, Missing/error in card verification data, Missing/error in amount, Missing/error in ordernum, Missing/error in currency', response.message
   end
-  
+
   def test_merchant_error
     @gateway.expects(:ssl_post).returns(merchant_error)
-    
+
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_equal response.message, 'Missing/error in merchant'
   end
-  
+
   def test_parsing_successful_response
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
-    
+
     response = @gateway.authorize(@amount, @credit_card, @options)
 
     assert_success response
     assert_equal 'OK', response.message
-    
+
     assert_equal '2865261', response.authorization
     assert_equal '000', response.params['qpstat']
     assert_equal '000', response.params['pbsstat']
@@ -113,11 +116,11 @@ class QuickpayTest < Test::Unit::TestCase
     assert_equal '1110', response.params['msgtype']
     assert_equal 'USD', response.params['currency']
   end
-  
+
   def test_supported_countries
     assert_equal ['DE', 'DK', 'ES', 'FI', 'FR', 'FO', 'GB', 'IS', 'NO', 'SE'], QuickpayGateway.supported_countries
   end
-  
+
   def test_supported_card_types
     assert_equal  [ :dankort, :forbrugsforeningen, :visa, :master, :american_express, :diners_club, :jcb, :maestro ], QuickpayGateway.supported_cardtypes
   end
@@ -127,37 +130,37 @@ class QuickpayTest < Test::Unit::TestCase
     @gateway.send(:add_testmode, post_hash)
     assert_equal nil, post_hash[:testmode]
   end
-  
+
   def test_add_testmode_adds_a_testmode_param_if_transaction_id_not_present
     post_hash = {}
     @gateway.send(:add_testmode, post_hash)
     assert_equal '1', post_hash[:testmode]
   end
-  
+
   private
-  
+
   def error_response
     "<?xml version='1.0' encoding='ISO-8859-1'?><response><qpstat>008</qpstat><qpstatmsg>Missing/error in cardnumber, Missing/error in expirationdate, Missing/error in card verification data, Missing/error in amount, Missing/error in ordernum, Missing/error in currency</qpstatmsg></response>"
   end
-  
+
   def merchant_error
     "<?xml version='1.0' encoding='ISO-8859-1'?><response><qpstat>008</qpstat><qpstatmsg>Missing/error in merchant</qpstatmsg></response>"
   end
-  
+
   def successful_authorization_response
     "<?xml version='1.0' encoding='ISO-8859-1'?><response><qpstat>000</qpstat><transaction>2865261</transaction><time>070425223705</time><ordernum>104680</ordernum><merchantemail>cody@example.com</merchantemail><pbsstat>000</pbsstat><cardtype>Visa</cardtype><amount>100</amount><qpstatmsg>OK</qpstatmsg><merchant>Shopify</merchant><msgtype>1110</msgtype><currency>USD</currency></response>"
   end
-  
+
   def successful_capture_response
     '<?xml version="1.0" encoding="ISO-8859-1"?><response><msgtype>1230</msgtype><amount>100</amount><time>080107061755</time><pbsstat>000</pbsstat><qpstat>000</qpstat><qpstatmsg>OK</qpstatmsg><currency>DKK</currency><ordernum>4820346075804536193</ordernum><transaction>2865261</transaction><merchant>Shopify</merchant><merchantemail>pixels@jadedpixel.com</merchantemail></response>'
   end
-  
+
   def successful_store_response_v6
-    '<?xml version="1.0" encoding="UTF-8"?><response><msgtype>subscribe</msgtype><ordernumber>fa73664073e23597bbdd</ordernumber><amount>0</amount><currency>n/a</currency><time>2014-02-26T21:25:47+01:00</time><state>9</state><qpstat>000</qpstat><qpstatmsg>OK</qpstatmsg><chstat>000</chstat><chstatmsg>OK</chstatmsg><merchant>Test Merchant</merchant><merchantemail>merchant@example.com</merchantemail><transaction>80760015</transaction><cardtype>visa</cardtype><cardnumber>XXXXXXXXXXXX4242</cardnumber><cardexpire>1509</cardexpire><splitpayment/><fraudprobability/><fraudremarks/><fraudreport/><md5check>6df8a5682079d580c7aba24e047a3d00</md5check></response>'
+    '<?xml version="1.0" encoding="UTF-8"?><response><msgtype>subscribe</msgtype><ordernumber>fa73664073e23597bbdd</ordernumber><amount>0</amount><currency>n/a</currency><time>2014-02-26T21:25:47+01:00</time><state>9</state><qpstat>000</qpstat><qpstatmsg>OK</qpstatmsg><chstat>000</chstat><chstatmsg>OK</chstatmsg><merchant>Test Merchant</merchant><merchantemail>merchant@example.com</merchantemail><transaction>80760015</transaction><cardtype>visa</cardtype><cardnumber>XXXXXXXXXXXX4242</cardnumber><cardexpire>1509</cardexpire><splitpayment/><fraudprobability/><fraudremarks/><fraudreport/><md5check>mock_hash</md5check></response>'
   end
 
   def successful_store_response_v7
-    '<?xml version="1.0" encoding="UTF-8"?><response><msgtype>subscribe</msgtype><ordernumber>ed7546cb4ceb8f017ea4</ordernumber><amount>0</amount><currency>DKK</currency><time>2014-02-26T21:04:00+01:00</time><state>9</state><qpstat>000</qpstat><qpstatmsg>OK</qpstatmsg><chstat>000</chstat><chstatmsg>OK</chstatmsg><merchant>Test Merchant</merchant><merchantemail>merchant@example.com</merchantemail><transaction>80758573</transaction><cardtype>visa</cardtype><cardnumber>XXXXXXXXXXXX4242</cardnumber><cardexpire>1509</cardexpire><splitpayment/><acquirer>nets</acquirer><fraudprobability/><fraudremarks/><fraudreport/><md5check>a7107c46c9d64031e228c6eb52b5afbe</md5check></response>'
+    '<?xml version="1.0" encoding="UTF-8"?><response><msgtype>subscribe</msgtype><ordernumber>ed7546cb4ceb8f017ea4</ordernumber><amount>0</amount><currency>DKK</currency><time>2014-02-26T21:04:00+01:00</time><state>9</state><qpstat>000</qpstat><qpstatmsg>OK</qpstatmsg><chstat>000</chstat><chstatmsg>OK</chstatmsg><merchant>Test Merchant</merchant><merchantemail>merchant@example.com</merchantemail><transaction>80758573</transaction><cardtype>visa</cardtype><cardnumber>XXXXXXXXXXXX4242</cardnumber><cardexpire>1509</cardexpire><splitpayment/><acquirer>nets</acquirer><fraudprobability/><fraudremarks/><fraudreport/><md5check>mock_hash</md5check></response>'
   end
 
   def failed_authorization_response
@@ -165,36 +168,42 @@ class QuickpayTest < Test::Unit::TestCase
   end
 
   def expected_store_parameters_v6
-    two_digit_year = (Time.now.year + 1).to_s[2,2]
     {
       "cardnumber"=>["4242424242424242"],
       "cvd"=>["123"],
-      "expirationdate"=>["#{two_digit_year}09"],
+      "expirationdate"=>[expected_expiration_date],
       "ordernumber"=>["fa73664073e23597bbdd"],
       "description"=>["Storing Card"],
       "testmode"=>["1"],
       "protocol"=>["6"],
       "msgtype"=>["subscribe"],
       "merchant"=>["LOGIN"],
-      "md5check"=>["8b7b3100fb835646723b9583febfb228"]
+      "md5check"=>[mock_md5_hash]
     }
   end
 
   def expected_store_parameters_v7
-    two_digit_year = (Time.now.year + 1).to_s[2,2]
     {
       "amount"=>["0"],
       "currency"=>["DKK"],
       "cardnumber"=>["4242424242424242"],
       "cvd"=>["123"],
-      "expirationdate"=>["#{two_digit_year}09"],
+      "expirationdate"=>[expected_expiration_date],
       "ordernumber"=>["ed7546cb4ceb8f017ea4"],
       "description"=>["Storing Card"],
       "testmode"=>["1"],
       "protocol"=>["7"],
       "msgtype"=>["subscribe"],
       "merchant"=>["LOGIN"],
-      "md5check"=>["5679173d581e33bf2c3d8ff772d01c9f"]
+      "md5check"=>[mock_md5_hash]
     }
+  end
+
+  def expected_expiration_date
+    '%02d%02d' % [@credit_card.year.to_s[2..4], @credit_card.month]
+  end
+
+  def mock_md5_hash
+    "mock_hash"
   end
 end

--- a/test/unit/gateways/sage_vault_test.rb
+++ b/test/unit/gateways/sage_vault_test.rb
@@ -19,7 +19,7 @@ class SageVaultGatewayTest < Test::Unit::TestCase
       assert_match(/<ns1:M_ID>login<\/ns1:M_ID>/, data)
       assert_match(/<ns1:M_KEY>password<\/ns1:M_KEY>/, data)
       assert_match(/<ns1:CARDNUMBER>#{credit_card.number}<\/ns1:CARDNUMBER>/, data)
-      assert_match(/<ns1:EXPIRATION_DATE>0915<\/ns1:EXPIRATION_DATE>/, data)
+      assert_match(/<ns1:EXPIRATION_DATE>#{expected_expiration_date}<\/ns1:EXPIRATION_DATE>/, data)
       assert_equal headers['SOAPAction'], 'https://www.sagepayments.net/web_services/wsVault/wsVault/INSERT_CREDIT_CARD_DATA'
     end.respond_with(successful_store_response)
 
@@ -37,7 +37,7 @@ class SageVaultGatewayTest < Test::Unit::TestCase
       assert_match(/<ns1:M_ID>login<\/ns1:M_ID>/, data)
       assert_match(/<ns1:M_KEY>password<\/ns1:M_KEY>/, data)
       assert_match(/<ns1:CARDNUMBER>#{credit_card.number}<\/ns1:CARDNUMBER>/, data)
-      assert_match(/<ns1:EXPIRATION_DATE>0915<\/ns1:EXPIRATION_DATE>/, data)
+      assert_match(/<ns1:EXPIRATION_DATE>#{expected_expiration_date}<\/ns1:EXPIRATION_DATE>/, data)
       assert_equal headers['SOAPAction'], 'https://www.sagepayments.net/web_services/wsVault/wsVault/INSERT_CREDIT_CARD_DATA'
     end.respond_with(failed_store_response)
 
@@ -81,6 +81,9 @@ class SageVaultGatewayTest < Test::Unit::TestCase
   end
 
   private
+  def expected_expiration_date
+    '%02d%02d' % [@credit_card.month, @credit_card.year.to_s[2..4]]
+  end
 
   def successful_store_response
     <<-XML


### PR DESCRIPTION
The default year used in the test_helper's `#credit_card` is `Time.now.year + 1` which broke a few of these tests.

I'm running all of the remotes locally right now to check them as well, but they're slooooowwwww

Also, Sublime nuked a bunch of whitespace, so you might want to `?w=1` or whatever this diff.

@ntalbott @girasquid 