### PR TITLE
CyberSource: Make :ignore_avs and :ignore_cvv settable on a per-transaction basis

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -242,7 +242,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new :indent => 2
         add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
         add_auth_service(xml)
-        add_business_rules_data(xml)
+        add_business_rules_data(xml, options)
         xml.target!
       end
 
@@ -253,7 +253,7 @@ module ActiveMerchant #:nodoc:
         add_line_item_data(xml, options)
         add_purchase_data(xml, 0, false, options)
         add_tax_service(xml)
-        add_business_rules_data(xml)
+        add_business_rules_data(xml, options)
         xml.target!
       end
 
@@ -264,7 +264,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new :indent => 2
         add_purchase_data(xml, money, true, options)
         add_capture_service(xml, request_id, request_token)
-        add_business_rules_data(xml)
+        add_business_rules_data(xml, options)
         xml.target!
       end
 
@@ -275,7 +275,7 @@ module ActiveMerchant #:nodoc:
           add_check_service(xml)
         else
           add_purchase_service(xml, options)
-          add_business_rules_data(xml) unless options[:pinless_debit_card]
+          add_business_rules_data(xml, options) unless options[:pinless_debit_card]
         end
         xml.target!
       end
@@ -344,7 +344,7 @@ module ActiveMerchant #:nodoc:
           end
         end
         add_subscription_create_service(xml, options)
-        add_business_rules_data(xml)
+        add_business_rules_data(xml, options)
         xml.target!
       end
 
@@ -356,7 +356,7 @@ module ActiveMerchant #:nodoc:
         add_creditcard_payment_method(xml) if creditcard
         add_subscription(xml, options, reference)
         add_subscription_update_service(xml, options)
-        add_business_rules_data(xml)
+        add_business_rules_data(xml, options)
         xml.target!
       end
 
@@ -381,10 +381,10 @@ module ActiveMerchant #:nodoc:
         xml.target!
       end
 
-      def add_business_rules_data(xml)
+      def add_business_rules_data(xml, options)
         xml.tag! 'businessRules' do
-          xml.tag!('ignoreAVSResult', 'true') if @options[:ignore_avs]
-          xml.tag!('ignoreCVResult', 'true') if @options[:ignore_cvv]
+          xml.tag!('ignoreAVSResult', 'true') if @options[:ignore_avs] || options[:ignore_avs]
+          xml.tag!('ignoreCVResult', 'true') if @options[:ignore_cvv] || options[:ignore_cvv]
         end
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -382,10 +382,19 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_business_rules_data(xml, options)
+        prioritized_options = [options, @options]
+
         xml.tag! 'businessRules' do
-          xml.tag!('ignoreAVSResult', 'true') if @options[:ignore_avs] || options[:ignore_avs]
-          xml.tag!('ignoreCVResult', 'true') if @options[:ignore_cvv] || options[:ignore_cvv]
+          xml.tag!('ignoreAVSResult', 'true') if extract_option(prioritized_options, :ignore_avs)
+          xml.tag!('ignoreCVResult', 'true') if extract_option(prioritized_options, :ignore_cvv)
         end
+      end
+
+      def extract_option prioritized_options, option_name
+        options_matching_key = prioritized_options.detect do |options|
+          options.has_key? option_name
+        end
+        options_matching_key[option_name] if options_matching_key
       end
 
       def add_line_item_data(xml, options)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -93,6 +93,58 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_credit_cart_purchase_single_request_ignore_avs
+    @gateway.expects(:ssl_post).with do |host, request_body|
+      assert_match %r'<ignoreAVSResult>true</ignoreAVSResult>', request_body
+      assert_not_match %r'<ignoreCVResult>', request_body
+      true
+    end.returns(successful_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
+      ignore_avs: true
+    ))
+    assert_success response
+  end
+
+  def test_successful_credit_cart_purchase_single_request_without_ignore_avs
+    @gateway.expects(:ssl_post).with do |host, request_body|
+      assert_not_match %r'<ignoreAVSResult>', request_body
+      assert_not_match %r'<ignoreCVResult>', request_body
+      true
+    end.returns(successful_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
+      ignore_avs: false
+    ))
+    assert_success response
+  end
+
+  def test_successful_credit_cart_purchase_single_request_ignore_ccv
+    @gateway.expects(:ssl_post).with do |host, request_body|
+      assert_not_match %r'<ignoreAVSResult>', request_body
+      assert_match %r'<ignoreCVResult>true</ignoreCVResult>', request_body
+      true
+    end.returns(successful_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
+      ignore_cvv: true
+    ))
+    assert_success response
+  end
+
+  def test_successful_credit_cart_purchase_single_request_without_ignore_ccv
+    @gateway.expects(:ssl_post).with do |host, request_body|
+      assert_not_match %r'<ignoreAVSResult>', request_body
+      assert_not_match %r'<ignoreCVResult>', request_body
+      true
+    end.returns(successful_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
+      ignore_cvv: false
+    ))
+    assert_success response
+  end
+
   def test_successful_reference_purchase
     @gateway.stubs(:ssl_post).returns(successful_create_subscription_response, successful_purchase_response)
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -113,6 +113,9 @@ class CyberSourceTest < Test::Unit::TestCase
       true
     end.returns(successful_purchase_response)
 
+    # globally ignored AVS for gateway instance:
+    @gateway.options[:ignore_avs] = true
+
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(
       ignore_avs: false
     ))


### PR DESCRIPTION
This small change makes it possible to create a Gateway instance with one `ignore_avs` or `:ignore_cvv` setting, and then override it in a single payment invocation. 

I hope this is a useful feature. I would however love feedback on the tests as this is my first `active_merchant` contribution. Is the testing at an appropriate level?