### PR TITLE
[QuickBooks Payments] Fix: Handle HTTP 400 status codes on failed transactions

### DIFF
--- a/test/remote/gateways/remote_quickbooks_test.rb
+++ b/test/remote/gateways/remote_quickbooks_test.rb
@@ -97,8 +97,9 @@ class RemoteTest < Test::Unit::TestCase
       token_secret: '',
       realm: ''
     )
-    response = gateway.purchase(@amount, @credit_card, @options)
-    assert_failure response
+    assert_raises ActiveMerchant::ResponseError do
+      gateway.purchase(@amount, @credit_card, @options)
+    end
   end
 
   def test_dump_transcript


### PR DESCRIPTION
Confronted during remote testing.

QuickBooks API returns an HTTP 400 status code for any failed transaction, even if the request is well-formed. :disappointed: 

Because active_utils raises an `ActiveMerchant::ResponseError` for HTTP status codes outside 200-300, legit-but-failed transactions are interpreted as any other bad request. 

This code captures `ResponseError`s and re-raises if there exists no JSON in its `response.body`, otherwise the JSON -- which includes the necessary error data -- is parsed and an `ActiveMerchant::Response` is constructed as usual. 

@ivanfer @j-mutter /cc @Shopify/active-merchant 