### PR TITLE
Update Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,20 @@
+language: ruby
+script: "bundle exec rake test:units"
+sudo: false
+
 rvm:
-  - 2.1.0
-  - 2.0.0
-  - 1.9.3
+- "2.2"
+- "2.1"
+- "2.0"
+- "1.9"
 
 gemfile:
-  - Gemfile
-  - Gemfile_rails40
-
-install: "bundle install"
-script: "bundle exec rake test:units"
+- Gemfile.rails32
+- Gemfile.rails40
+- Gemfile.rails41
+- Gemfile.rails42
 
 notifications:
   email:
-    - payments-dev@shopify.com
-    - nathaniel@talbott.ws
+  - payments-dev@shopify.com
+  - nathaniel@talbott.ws

--- a/Gemfile.rails32
+++ b/Gemfile.rails32
@@ -1,10 +1,12 @@
-group :test do
-  gem 'json-jruby', :platforms => :jruby
-  gem 'jruby-openssl', :platforms => :jruby
-end
+source 'https://rubygems.org'
+gemspec
+
+gem 'jruby-openssl', :platforms => :jruby
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
   gem 'braintree', '>= 2.0.0'
   gem 'oauth', '0.4.7'
 end
+
+gem 'rails', '~> 3.2.0'

--- a/Gemfile.rails40
+++ b/Gemfile.rails40
@@ -8,3 +8,5 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.0.0'
   gem 'oauth', '0.4.7'
 end
+
+gem 'rails', '~> 4.0.0'

--- a/Gemfile.rails41
+++ b/Gemfile.rails41
@@ -8,3 +8,5 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.0.0'
   gem 'oauth', '0.4.7'
 end
+
+gem 'rails', '~> 4.1.0'

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -8,3 +8,5 @@ group :test, :remote_test do
   gem 'braintree', '>= 2.0.0'
   gem 'oauth', '0.4.7'
 end
+
+gem 'rails', '~> 4.2.0'

--- a/Gemfile_rails40
+++ b/Gemfile_rails40
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'rails', '~> 4.0.0'
-
-eval File.read(File.expand_path("../Gemfile_common", __FILE__))

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency("offsite_payments", "~> 2.0.0")
 
   s.add_development_dependency('rake')
+  s.add_development_dependency('test-unit', '~> 1.2.3')
   s.add_development_dependency('mocha', '~> 0.13.0')
   s.add_development_dependency('rails', '>= 3.2.14')
   s.add_development_dependency('thor')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,22 +1,13 @@
 #!/usr/bin/env ruby
 $:.unshift File.expand_path('../../lib', __FILE__)
 
-begin
-  require 'rubygems'
-  require 'bundler'
-  Bundler.setup
-rescue LoadError => e
-  puts "Error loading bundler (#{e.message}): \"gem install bundler\" for bundler support."
-end
+require 'bundler/setup'
 
 require 'test/unit'
 
 require 'mocha/version'
-if(Mocha::VERSION.split(".")[1].to_i < 12)
-  require 'mocha'
-else
-  require 'mocha/setup'
-end
+require 'mocha/setup'
+
 require 'yaml'
 require 'json'
 require 'active_merchant'
@@ -47,7 +38,7 @@ end
 
 module ActiveMerchant
   module Assertions
-    AssertionClass = RUBY_VERSION > '1.9' ? MiniTest::Assertion : Test::Unit::AssertionFailedError
+    AssertionClass = defined?(Minitest) ? MiniTest::Assertion : Test::Unit::AssertionFailedError
 
     def assert_field(field, value)
       clean_backtrace do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,8 +4,6 @@ $:.unshift File.expand_path('../../lib', __FILE__)
 require 'bundler/setup'
 
 require 'test/unit'
-
-require 'mocha/version'
 require 'mocha/setup'
 
 require 'yaml'
@@ -111,6 +109,10 @@ module ActiveMerchant
     def assert_deprecation_warning(message=nil)
       ActiveMerchant.expects(:deprecated).with(message ? message : anything)
       yield
+    end
+
+    def refute(value, message = nil)
+      assert(!value, message)
     end
 
     def silence_deprecation_warnings

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -261,7 +261,7 @@ class LitleTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card)
     end.check_request do |endpoint, data, headers|
       assert_match "<orderSource>ecommerce</orderSource>", data
-      assert_not_match %r{<pos>.+<\/pos>}m, data
+      assert %r{<pos>.+<\/pos>}m !~ data
     end.respond_with(successful_purchase_response)
   end
 

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'digest/sha1'
 
 class RealexTest < Test::Unit::TestCase
   class ActiveMerchant::Billing::RealexGateway
@@ -55,7 +54,7 @@ class RealexTest < Test::Unit::TestCase
       :login => 'thestore',
       :password => 'mysecret'
     )
-    Time.stubs(:now).returns(Time.parse("2001-04-03 12:32:45"))
+    Time.stubs(:now).returns(Time.new(2001, 4, 3, 12, 32, 45))
     gateway.expects(:ssl_post).with(anything, regexp_matches(/9af7064afd307c9f988e8dfc271f9257f1fc02f6/)).returns(successful_purchase_response)
     gateway.purchase(29900, credit_card('5105105105105100'), :order_id => 'ORD453-11')
   end


### PR DESCRIPTION
This updates the Travis CI build matrix.

- Also test against Ruby 2.2
- Tests more explicitly specified versions of Rails / ActiveSupport.

CircleCI will test against the latest dependency versions that meet the gemspec. We should see if we can open source this project there; I think this is now supported.

@j-mutter @girasquid @aprofeit @ntalbott for review.