### PR TITLE
Clean up some tests

### DIFF
--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -94,8 +94,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_fractional_currency
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
     @gateway.expects(:post_data).with do |params|
-      assert_equal '100', params['paymentRequest.amount.value']
-      assert_equal 'JPY', params['paymentRequest.amount.currency']
+      '100' == params['paymentRequest.amount.value'] && 'JPY' == params['paymentRequest.amount.currency']
     end
 
     @options[:currency] = 'JPY'

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -129,7 +129,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     result = Braintree::SuccessfulResult.new(:customer => customer)
 
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
-      assert_equal 'merchant_account_id', params[:credit_card][:options][:verification_merchant_account_id]
+      'merchant_account_id' == params[:credit_card][:options][:verification_merchant_account_id]
     end.returns(result)
 
     gateway.store(credit_card('41111111111111111111'), :verify_card => true)
@@ -151,7 +151,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     customer.stubs(:id).returns('123')
     result = Braintree::SuccessfulResult.new(:customer => customer)
     Braintree::CustomerGateway.any_instance.expects(:create).with do |params|
-      assert_equal 'value_from_options', params[:credit_card][:options][:verification_merchant_account_id]
+      'value_from_options' == params[:credit_card][:options][:verification_merchant_account_id]
     end.returns(result)
 
     gateway.store(credit_card('41111111111111111111'), :verify_card => true, :verification_merchant_account_id => 'value_from_options')

--- a/test/unit/gateways/bridge_pay_test.rb
+++ b/test/unit/gateways/bridge_pay_test.rb
@@ -13,6 +13,7 @@ class BridgePayTest < Test::Unit::TestCase
 
     @credit_card = credit_card
     @amount = 100
+    @options = {}
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -14,6 +14,7 @@ class LitleTest < Test::Unit::TestCase
 
     @credit_card = credit_card
     @amount = 100
+    @options = {}
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/network_merchants_test.rb
+++ b/test/unit/gateways/network_merchants_test.rb
@@ -22,7 +22,7 @@ class NetworkMerchantsTest < Test::Unit::TestCase
     @credit_card.track_data = "data"
 
     @gateway.expects(:ssl_post).with do |_, body|
-      assert_match "track_1=data", body
+      body.include?("track_1=data")
     end.returns(successful_purchase_response)
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -165,7 +165,7 @@ class NetworkMerchantsTest < Test::Unit::TestCase
 
   def test_currency_uses_default_when_not_provided
     @gateway.expects(:ssl_post).with do |_, body|
-      assert_match "currency=USD", body
+      body.include?("currency=USD")
     end.returns(successful_purchase_response)
 
     @gateway.purchase(@amount, @credit_card, @options)
@@ -174,7 +174,7 @@ class NetworkMerchantsTest < Test::Unit::TestCase
   def test_provided_currency_overrides_default
     @options.update(currency: 'EUR')
     @gateway.expects(:ssl_post).with do |_, body|
-      assert_match "currency=EUR", body
+      body.include?("currency=EUR")
     end.returns(successful_purchase_response)
 
     @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -9,6 +9,7 @@ class NmiTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card
+    @options = {}
   end
 
   def test_credit_card_purchase_no_recurring_flag

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -185,7 +185,7 @@ class StripeTest < Test::Unit::TestCase
   def test_amount_localization
     @gateway.expects(:ssl_request).returns(successful_purchase_response(true))
     @gateway.expects(:post_data).with do |params|
-      assert_equal '4', params[:amount]
+      '4' == params[:amount]
     end
 
     @options[:currency] = 'JPY'
@@ -243,7 +243,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_successful_refund_with_refund_application_fee
     @gateway.expects(:ssl_request).with do |method, url, post, headers|
-      assert post.include?("refund_application_fee=true")
+      post.include?("refund_application_fee=true")
     end.returns(successful_partially_refunded_response)
 
     assert response = @gateway.refund(@refund_amount, 'ch_test_charge', :refund_application_fee => true)
@@ -435,7 +435,7 @@ class StripeTest < Test::Unit::TestCase
       assert_match(/user_agent=some\+browser/, data)
       assert_match(/referrer=http\%3A\%2F\%2Fwww\.shopify\.com/, data)
       assert_match(/payment_user_agent=Stripe\%2Fv1\+ActiveMerchantBindings\%2F\d+\.\d+\.\d+/, data)
-      refute_match(/metadata/, data)
+      refute data.include?('metadata')
     end.respond_with(successful_purchase_response)
   end
 
@@ -517,7 +517,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_passing_expand_parameters
     @gateway.expects(:ssl_request).with do |method, url, post, headers|
-      assert post.include?("expand[]=balance_transaction")
+      post.include?("expand[]=balance_transaction")
     end.returns(successful_authorization_response)
 
     @options.merge!(:expand => :balance_transaction)
@@ -527,7 +527,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_passing_expand_parameters_as_array
     @gateway.expects(:ssl_request).with do |method, url, post, headers|
-      assert post.include?("expand[]=balance_transaction&expand[]=customer")
+      post.include?("expand[]=balance_transaction&expand[]=customer")
     end.returns(successful_authorization_response)
 
     @options.merge!(:expand => [:balance_transaction, :customer])
@@ -537,7 +537,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_recurring_flag_not_set_by_default
     @gateway.expects(:ssl_request).with do |method, url, post, headers|
-      assert !post.include?("recurring")
+      !post.include?("recurring")
     end.returns(successful_authorization_response)
 
     @gateway.authorize(@amount, @credit_card, @options)
@@ -545,7 +545,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_passing_recurring_eci_sets_recurring_flag
     @gateway.expects(:ssl_request).with do |method, url, post, headers|
-      assert post.include?("recurring=true")
+      post.include?("recurring=true")
     end.returns(successful_authorization_response)
 
     @options.merge!(eci: 'recurring')
@@ -555,7 +555,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_passing_unknown_eci_does_not_set_recurring_flag
     @gateway.expects(:ssl_request).with do |method, url, post, headers|
-      assert !post.include?("recurring")
+      !post.include?("recurring")
     end.returns(successful_authorization_response)
 
     @options.merge!(eci: 'installment')
@@ -565,7 +565,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_passing_recurring_true_option_sets_recurring_flag
     @gateway.expects(:ssl_request).with do |method, url, post, headers|
-      assert post.include?("recurring=true")
+      post.include?("recurring=true")
     end.returns(successful_authorization_response)
 
     @options.merge!(recurring: true)
@@ -575,7 +575,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_passing_recurring_false_option_does_not_set_recurring_flag
     @gateway.expects(:ssl_request).with do |method, url, post, headers|
-      assert !post.include?("recurring")
+      !post.include?("recurring")
     end.returns(successful_authorization_response)
 
     @options.merge!(recurring: false)

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -49,7 +49,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert response.test?
-    assert Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code 
+    assert Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
   end
 
   def test_successful_purchase_passing_extra_info
@@ -166,7 +166,7 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     @credit_card.track_data = "data"
 
     @gateway.expects(:ssl_post).with do |_, body|
-      assert_match "UMmagstripe=data", body
+      body.include?("UMmagstripe=data")
     end.returns(successful_purchase_response)
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
- When using mocha's `with` parameter matcher, you should not use assertions inside the block, but return true or false.
- Using uninitialized instance variables has different effect in different ruby versions. Make sure `@options` is set before using it in `@gateway.verify(@credit_card, @options)` calls.

Currently, these issues do not make the test suit fail due to the magic Ruby + mocha + test-unit/minitest version combination, but it fails when I change those.

@Shopify/payments @ntalbott for review