### PR TITLE
Drop init.rb

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,0 @@
-require 'active_merchant'


### PR DESCRIPTION
`init.rb` is only needed for people that have installed activemerchant in Rails 2 as a rails plugin, and are not using bundler.

@ntalbott @Shopify/payments 

 