### PR TITLE
[QuickBooks Payments] remove oauth gem, implement OAuth request signing in QuickbooksGateway

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,4 @@ gem 'jruby-openssl', :platforms => :jruby
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
   gem 'braintree', '>= 2.0.0'
-  gem 'oauth', '0.4.7'
 end

--- a/test/remote/gateways/remote_quickbooks_test.rb
+++ b/test/remote/gateways/remote_quickbooks_test.rb
@@ -103,7 +103,6 @@ class RemoteTest < Test::Unit::TestCase
   end
 
   def test_dump_transcript
-    skip('See quickbooks_test.rb for a scrubbed transcript')
-    dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
+    # See quickbooks_test.rb for an example of a scrubbed transcript
   end
 end


### PR DESCRIPTION
Upon inspection of the `oauth` gem at https://github.com/oauth-xx/oauth-ruby, we noticed [the default HMAC-SHA1 mechanism](https://github.com/oauth-xx/oauth-ruby/blob/master/lib/digest/hmac.rb) used to sign requests is [officially discouraged](http://www.ruby-doc.org/stdlib-2.0/libdoc/digest/rdoc/Digest/HMAC.html) and thus unacceptable for deployment in a PCI environment. 

This removes the gem dependency and isolates OAuth 1.0a request signing into the QuickBooks Payments adapter, and uses the OpenSSL implementation of HMAC instead, as suggested by the official Ruby documentation.

@girasquid @ntalbott /cc @Shopify/active-merchant 