### PR TITLE
Remove duplicate hash keys that were causing warnings

### DIFF
--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -266,7 +266,6 @@ module ActiveMerchant #:nodoc:
         "55" => "The 4-digit pin is invalid.",
         "75" => "Maximum number of pin retries exceeded.",
         "80" => "Card expiration date is invalid.",
-        "80" => "Card expiration date is invalid.",
         "86" => "Can't verify card pin number."
       }
       def issuer_message(code)

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -46,7 +46,6 @@ module ActiveMerchant #:nodoc:
         "N" => "Neither street address nor zip/postal match billing information",
         "O" => "Non-US issuer does not participate",
         "P" => "Postal codes match for international transaction but street address not verified due to incompatible formats",
-        "P" => "Address verification not applicable for this transaction",
         "R" => "Payment gateway was unavailable or timed out",
         "S" => "Address verification service not supported by issuer",
         "U" => "Address information is unavailable",

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -395,7 +395,6 @@ module ActiveMerchant #:nodoc:
         "U" => "U", # Data Not Checked
         "Y" => "D", # All Data Matched
         "Z" => "P", # CSC and Postcode Matched
-        "F" => "D"  # Street address and zip code match
       }
 
       # Amex have different AVS response codes to visa etc


### PR DESCRIPTION
When hash keys are redefined, the last occurrence will be kept.

- For skipjack, I kept the one that I could find in their docs: http://imgserver.skipjack.com/imgServer/5293710/AVS%20and%20CVV2.pdf
- WireCard and HPS were just duplicates, so I removed the last occurrence.

@ntalbott @Shopify/payments for review