### PR TITLE
Don't use relative requires

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/beanstream/beanstream_core'
+require 'active_merchant/billing/gateways/beanstream/beanstream_core'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/beanstream_interac.rb
+++ b/lib/active_merchant/billing/gateways/beanstream_interac.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/beanstream/beanstream_core'
+require 'active_merchant/billing/gateways/beanstream/beanstream_core'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -7,21 +7,21 @@ module ActiveMerchant #:nodoc:
         params['pageContents']
       end
     end
-    
+
     class BeanstreamInteracGateway < Gateway
       include BeanstreamCore
 
       # Confirm a transaction posted back from the bank to Beanstream.
       # Confirming a transaction does not require any credentials,
       # and in an application with many merchants sharing a funded
-      # URL the application may not yet know which merchant the 
+      # URL the application may not yet know which merchant the
       # post back is for until the response of the confirmation is
       # received, which contains the order number.
       def self.confirm(transaction)
         gateway = new(:login => '')
         gateway.confirm(transaction)
       end
-      
+
       def purchase(money, options = {})
         post = {}
         add_amount(post, money)
@@ -31,20 +31,20 @@ module ActiveMerchant #:nodoc:
         add_transaction_type(post, :purchase)
         commit(post)
       end
-      
+
       # Confirm a transaction posted back from the bank to Beanstream.
       def confirm(transaction)
         post(transaction)
       end
-      
+
       private
-      
+
       def add_interac_details(post, options)
         address = options[:billing_address] || options[:address] || {}
         post[:trnCardOwner] = address[:name]
         post[:paymentMethod] = 'IO'
       end
-      
+
       def build_response(*args)
         BeanstreamInteracResponse.new(*args)
       end

--- a/lib/active_merchant/billing/gateways/braintree.rb
+++ b/lib/active_merchant/billing/gateways/braintree.rb
@@ -1,10 +1,10 @@
-require File.dirname(__FILE__) + '/braintree/braintree_common'
+require 'active_merchant/billing/gateways/braintree/braintree_common'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class BraintreeGateway < Gateway
       include BraintreeCommon
-      
+
       self.abstract_class = true
 
       def self.new(options={})

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/braintree/braintree_common'
+require 'active_merchant/billing/gateways/braintree/braintree_common'
 
 begin
   require "braintree"

--- a/lib/active_merchant/billing/gateways/braintree_orange.rb
+++ b/lib/active_merchant/billing/gateways/braintree_orange.rb
@@ -1,5 +1,5 @@
-require File.dirname(__FILE__) +  '/smart_ps.rb'
-require File.dirname(__FILE__) + '/braintree/braintree_common'
+require 'active_merchant/billing/gateways/smart_ps.rb'
+require 'active_merchant/billing/gateways/braintree/braintree_common'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/viaklix'
+require 'active_merchant/billing/gateways/viaklix'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/finansbank.rb
+++ b/lib/active_merchant/billing/gateways/finansbank.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/cc5'
+require 'active_merchant/billing/gateways/cc5'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/ideal/ideal_base.rb
+++ b/lib/active_merchant/billing/gateways/ideal/ideal_base.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/ideal_response'
+require 'active_merchant/billing/gateways/ideal/ideal_response'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/ideal_rabobank.rb
+++ b/lib/active_merchant/billing/gateways/ideal_rabobank.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/ideal/ideal_base'
+require 'active_merchant/billing/gateways/ideal/ideal_base'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/migs/migs_codes'
+require 'active_merchant/billing/gateways/migs/migs_codes'
 
 require 'digest/md5' # Used in add_secure_hash
 

--- a/lib/active_merchant/billing/gateways/modern_payments.rb
+++ b/lib/active_merchant/billing/gateways/modern_payments.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/modern_payments_cim'
+require 'active_merchant/billing/gateways/modern_payments_cim'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/orbital/orbital_soft_descriptors'
+require 'active_merchant/billing/gateways/orbital/orbital_soft_descriptors'
 require "rexml/document"
 
 module ActiveMerchant #:nodoc:

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -1,6 +1,6 @@
-require File.dirname(__FILE__) + '/payflow/payflow_common_api'
-require File.dirname(__FILE__) + '/payflow/payflow_response'
-require File.dirname(__FILE__) + '/payflow_express'
+require 'active_merchant/billing/gateways/payflow/payflow_common_api'
+require 'active_merchant/billing/gateways/payflow/payflow_response'
+require 'active_merchant/billing/gateways/payflow_express'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/payflow_express.rb
+++ b/lib/active_merchant/billing/gateways/payflow_express.rb
@@ -1,6 +1,6 @@
-require File.dirname(__FILE__) + '/payflow/payflow_common_api'
-require File.dirname(__FILE__) + '/payflow/payflow_express_response'
-require File.dirname(__FILE__) + '/paypal_express_common'
+require 'active_merchant/billing/gateways/payflow/payflow_common_api'
+require 'active_merchant/billing/gateways/payflow/payflow_express_response'
+require 'active_merchant/billing/gateways/paypal_express_common'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/payflow_express_uk.rb
+++ b/lib/active_merchant/billing/gateways/payflow_express_uk.rb
@@ -1,11 +1,11 @@
-require File.dirname(__FILE__) + '/payflow_express'
+require 'active_merchant/billing/gateways/payflow_express'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PayflowExpressUkGateway < PayflowExpressGateway
       self.default_currency = 'GBP'
       self.partner = 'PayPalUk'
-      
+
       self.supported_countries = ['GB']
       self.homepage_url = 'https://www.paypal.com/uk/cgi-bin/webscr?cmd=_additional-payment-overview-outside'
       self.display_name = 'PayPal Express Checkout (UK)'

--- a/lib/active_merchant/billing/gateways/payflow_uk.rb
+++ b/lib/active_merchant/billing/gateways/payflow_uk.rb
@@ -1,16 +1,16 @@
-require File.dirname(__FILE__) + '/payflow'
-require File.dirname(__FILE__) + '/payflow_express_uk' 
+require 'active_merchant/billing/gateways/payflow'
+require 'active_merchant/billing/gateways/payflow_express_uk'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PayflowUkGateway < PayflowGateway
       self.default_currency = 'GBP'
       self.partner = 'PayPalUk'
-      
+
       def express
         @express ||= PayflowExpressUkGateway.new(@options)
       end
-      
+
       self.supported_cardtypes = [:visa, :master, :american_express, :discover, :solo, :switch]
       self.supported_countries = ['GB']
       self.homepage_url = 'https://www.paypal.com/uk/webapps/mpp/pro'

--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -1,6 +1,6 @@
-require File.dirname(__FILE__) + '/paypal/paypal_common_api'
-require File.dirname(__FILE__) + '/paypal/paypal_recurring_api'
-require File.dirname(__FILE__) + '/paypal_express'
+require 'active_merchant/billing/gateways/paypal/paypal_common_api'
+require 'active_merchant/billing/gateways/paypal/paypal_recurring_api'
+require 'active_merchant/billing/gateways/paypal_express'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/paypal/paypal_recurring_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_recurring_api.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/paypal_common_api'
+require 'active_merchant/billing/gateways/paypal/paypal_common_api'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/paypal_ca.rb
+++ b/lib/active_merchant/billing/gateways/paypal_ca.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/paypal'
+require 'active_merchant/billing/gateways/paypal'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
+++ b/lib/active_merchant/billing/gateways/paypal_digital_goods.rb
@@ -1,6 +1,6 @@
-require File.dirname(__FILE__) + '/paypal/paypal_common_api'
-require File.dirname(__FILE__) + '/paypal/paypal_express_response'
-require File.dirname(__FILE__) + '/paypal_express_common'
+require 'active_merchant/billing/gateways/paypal/paypal_common_api'
+require 'active_merchant/billing/gateways/paypal/paypal_express_response'
+require 'active_merchant/billing/gateways/paypal_express_common'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -1,7 +1,7 @@
-require File.dirname(__FILE__) + '/paypal/paypal_common_api'
-require File.dirname(__FILE__) + '/paypal/paypal_express_response'
-require File.dirname(__FILE__) + '/paypal/paypal_recurring_api'
-require File.dirname(__FILE__) + '/paypal_express_common'
+require 'active_merchant/billing/gateways/paypal/paypal_common_api'
+require 'active_merchant/billing/gateways/paypal/paypal_express_response'
+require 'active_merchant/billing/gateways/paypal/paypal_recurring_api'
+require 'active_merchant/billing/gateways/paypal_express_common'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -1,6 +1,6 @@
-require File.dirname(__FILE__) + '/sage/sage_bankcard'
-require File.dirname(__FILE__) + '/sage/sage_virtual_check'
-require File.dirname(__FILE__) + '/sage/sage_vault'
+require 'active_merchant/billing/gateways/sage/sage_bankcard'
+require 'active_merchant/billing/gateways/sage/sage_virtual_check'
+require 'active_merchant/billing/gateways/sage/sage_vault'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/sage/sage_bankcard.rb
+++ b/lib/active_merchant/billing/gateways/sage/sage_bankcard.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/sage_core'
+require 'active_merchant/billing/gateways/sage/sage_core'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/sage/sage_virtual_check.rb
+++ b/lib/active_merchant/billing/gateways/sage/sage_virtual_check.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/sage_core'
+require 'active_merchant/billing/gateways/sage/sage_core'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/lib/active_merchant/billing/gateways/secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/authorize_net'
+require 'active_merchant/billing/gateways/authorize_net'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:

--- a/test/remote/gateways/remote_inspire_test.rb
+++ b/test/remote/gateways/remote_inspire_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../test_helper'
+require 'test_helper'
 
 class RemoteBraintreeTest < Test::Unit::TestCase
   def setup
@@ -11,20 +11,20 @@ class RemoteBraintreeTest < Test::Unit::TestCase
                   :billing_address => address
                }
   end
-  
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'This transaction has been approved', response.message
     assert_success response
   end
-  
+
   def test_successful_purchase_with_old_naming
     gateway = InspireGateway.new(fixtures(:inspire))
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'This transaction has been approved', response.message
     assert_success response
   end
-  
+
   def test_successful_purchase_with_echeck
     check = ActiveMerchant::Billing::Check.new(
               :name => 'Fredd Bloggs',
@@ -37,7 +37,7 @@ class RemoteBraintreeTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved', response.message
     assert_success response
   end
-  
+
   def test_successful_add_to_vault
     @options[:store] = true
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -59,12 +59,12 @@ class RemoteBraintreeTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved', response.message
     assert_success response
     assert_not_nil customer_id = response.params["customer_vault_id"]
-    
+
     assert second_response = @gateway.purchase(@amount*2, customer_id, @options)
     assert_equal 'This transaction has been approved', second_response.message
-    assert second_response.success?  
+    assert second_response.success?
   end
-  
+
   def test_add_to_vault_with_custom_vault_id
     @options[:store] = rand(100000)+10001
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -72,7 +72,7 @@ class RemoteBraintreeTest < Test::Unit::TestCase
     assert_success response
     assert_equal @options[:store], response.params["customer_vault_id"].to_i
   end
-  
+
   def test_add_to_vault_with_custom_vault_id_with_store_method
     @options[:billing_id] = rand(100000)+10001
     assert response = @gateway.store(@credit_card, @options.dup)
@@ -80,7 +80,7 @@ class RemoteBraintreeTest < Test::Unit::TestCase
     assert_success response
     assert_equal @options[:billing_id], response.params["customer_vault_id"].to_i
   end
-  
+
   def test_update_vault
     test_add_to_vault_with_custom_vault_id
     @credit_card = credit_card('4111111111111111', :month => 10)
@@ -88,7 +88,7 @@ class RemoteBraintreeTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Customer Update Successful', response.message
   end
-  
+
   def test_delete_from_vault
     test_add_to_vault_with_custom_vault_id
     assert response = @gateway.delete(@options[:store])
@@ -118,7 +118,7 @@ class RemoteBraintreeTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved', capture.message
     assert_success capture
   end
-  
+
   def test_authorize_and_void
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth


### PR DESCRIPTION
A library shouldn't use relative requires. You can/should assume that the dependency manager (e.g. bundler) has set the `$LOAD_PATH` correctly to include `lib` (and `test` in test mode). Using relative requires can cause double loading of files in some cases, which can be a subtle source of bugs and warnings. 

If you really need to require a file relative to the current file, use `require_relative`, but we don't need it in this gem.