### PR TITLE
Orbital: Handle incorrectly encoded response

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -427,7 +427,7 @@ module ActiveMerchant #:nodoc:
 
       def parse(body)
         response = {}
-        xml = REXML::Document.new(body)
+        xml = REXML::Document.new(body.encoding.name == "UTF-8" ? body : body.encode("UTF-8", "ISO-8859-1"))
         root = REXML::XPath.first(xml, "//Response") ||
                REXML::XPath.first(xml, "//ErrorResponse")
         if root

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -495,6 +495,12 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_nil response.params['account_num']
   end
 
+  def test_handling_incorrectly_encoded_message
+    @gateway.expects(:ssl_post).returns(incorrectly_encoded_response)
+
+    assert_nothing_raised { @gateway.purchase(50, credit_card, :order_id => '1') }
+  end
+
   private
 
   def successful_purchase_response(resp_code = '00')
@@ -511,5 +517,9 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def successful_void_response
     %q{<?xml version="1.0" encoding="UTF-8"?><Response><ReversalResp><MerchantID>700000208761</MerchantID><TerminalID>001</TerminalID><OrderID>2</OrderID><TxRefNum>50FB1C41FEC9D016FF0BEBAD0884B174AD0853B0</TxRefNum><TxRefIdx>1</TxRefIdx><OutstandingAmt>0</OutstandingAmt><ProcStatus>0</ProcStatus><StatusMsg></StatusMsg><RespTime>01192013172049</RespTime></ReversalResp></Response>}
+  end
+
+  def incorrectly_encoded_response
+    successful_purchase_response.gsub("<CustomerName></CustomerName>", "<CustomerName>J\xFCrgen</CustomerName>").force_encoding("ISO-8859-1")
   end
 end


### PR DESCRIPTION
When an order contains non-standard characters (normally in the
customer's name and is normally accented characters) and is submitted
to Orbital, they will send back an XML response flagged as UTF-8 but is
actually ISO-8859-1. This causes parsers like REXML to raise an
exception while parsing what it thinks is UTF-8.