### PR TITLE
Update compatibility.rb

### DIFF
--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -13,7 +13,6 @@ module ActiveMerchant
         end
       end
 
-      @rails_required = false
       def self.rails_required!
         @rails_required = true
       end


### PR DESCRIPTION
This is an instance variable - variable being used for rails compatibility is a class instance variable. No need for this