### PR TITLE
add support for partial refunds + captures

### DIFF
--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -75,16 +75,18 @@ module ActiveMerchant #:nodoc:
       end
 
       def capture(money, authorization, options = {})
+        post = {}
         capture_uri = "#{ENDPOINT}/#{CGI.escape(authorization)}/capture"
+        post[:amount] = localized_amount(money, currency(money))
 
-        commit(capture_uri)
+        commit(capture_uri, post)
       end
 
       def refund(money, authorization, options = {})
         post = {}
-        refund_uri = "#{ENDPOINT}/#{CGI.escape(authorization)}/refunds"
+        post[:amount] = localized_amount(money, currency(money))
 
-        commit(refund_uri, post)
+        commit(refund_uri(authorization), post)
       end
 
       def verify(credit_card, options = {})
@@ -234,7 +236,7 @@ module ActiveMerchant #:nodoc:
       def cvv_code_from(response)
         if response['errors'].present?
           FRAUD_WARNING_CODES.include?(response['errors'].first['code']) ? 'I' : ''
-        elsif
+        else
           success?(response) ? 'M' : ''
         end
       end
@@ -266,6 +268,10 @@ module ActiveMerchant #:nodoc:
           raise response_error
         end
         response_error.response.body
+      end
+
+      def refund_uri(authorization)
+        "#{ENDPOINT}/#{CGI.escape(authorization)}/refunds"
       end
     end
   end


### PR DESCRIPTION
#### QBP updates

This PR adds support for partial captures and refunds, and makes remote tests a little more explicit.

Thought we would be able to add in voids for Quickbooks Payments in this PR, but without passing remote tests for them, it's a feature we'll add later.

for review: @bizla @girasquid @ntalbott 

