### PR TITLE
Add finalize option to quickpay at capture

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -19,7 +19,7 @@ module ActiveMerchant #:nodoc:
                            currency autocapture cardnumber expirationdate
                            cvd cardtypelock testmode),
 
-          :capture   => %w(protocol msgtype merchant amount transaction),
+          :capture   => %w(protocol msgtype merchant amount finalize transaction),
 
           :cancel    => %w(protocol msgtype merchant transaction),
 
@@ -44,7 +44,7 @@ module ActiveMerchant #:nodoc:
                            fraud_http_accept_encoding fraud_http_accept_charset
                            fraud_http_referer fraud_http_user_agent apikey),
 
-          :capture   => %w(protocol msgtype merchant amount transaction apikey),
+          :capture   => %w(protocol msgtype merchant amount finalize transaction apikey),
 
           :cancel    => %w(protocol msgtype merchant transaction apikey),
 
@@ -72,7 +72,7 @@ module ActiveMerchant #:nodoc:
                            fraud_http_accept_encoding fraud_http_accept_charset
                            fraud_http_referer fraud_http_user_agent apikey),
 
-          :capture   => %w(protocol msgtype merchant amount transaction apikey),
+          :capture   => %w(protocol msgtype merchant amount finalize transaction apikey),
 
           :cancel    => %w(protocol msgtype merchant transaction apikey),
 
@@ -100,7 +100,7 @@ module ActiveMerchant #:nodoc:
                            fraud_http_accept_encoding fraud_http_accept_charset
                            fraud_http_referer fraud_http_user_agent apikey),
 
-          :capture   => %w(protocol msgtype merchant amount transaction
+          :capture   => %w(protocol msgtype merchant amount finalize transaction
                            apikey),
 
           :cancel    => %w(protocol msgtype merchant transaction apikey),
@@ -129,7 +129,7 @@ module ActiveMerchant #:nodoc:
                            fraud_http_accept_encoding fraud_http_accept_charset
                            fraud_http_referer fraud_http_user_agent apikey),
 
-          :capture   => %w(protocol msgtype merchant amount transaction
+          :capture   => %w(protocol msgtype merchant amount finalize transaction
                            apikey),
 
           :cancel    => %w(protocol msgtype merchant transaction apikey),
@@ -196,6 +196,7 @@ module ActiveMerchant #:nodoc:
       def capture(money, authorization, options = {})
         post = {}
 
+        add_finalize(post, options)
         add_reference(post, authorization)
         add_amount_without_currency(post, money)
         commit(:capture, post)
@@ -298,6 +299,10 @@ module ActiveMerchant #:nodoc:
           post[:fraud_http_referer] = options[:fraud_http_referer] if options[:fraud_http_referer]
           post[:fraud_http_user_agent] = options[:fraud_http_user_agent] if options[:fraud_http_user_agent]
         end
+      end
+
+      def add_finalize(post, options)
+        post[:finalize] = options[:finalize] ? '1' : '0'
       end
 
       def commit(action, params)

--- a/test/unit/gateways/quickpay_test.rb
+++ b/test/unit/gateways/quickpay_test.rb
@@ -133,6 +133,22 @@ class QuickpayTest < Test::Unit::TestCase
     @gateway.send(:add_testmode, post_hash)
     assert_equal '1', post_hash[:testmode]
   end
+
+  def test_finalize_is_disabled_by_default
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.capture(@amount, "12345")
+    end.check_request do |method, endpoint, data, headers|
+      assert data =~ /finalize=0/
+    end.respond_with(successful_capture_response)
+  end
+
+  def test_finalize_is_enabled
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.capture(@amount, "12345", finalize: true)
+    end.check_request do |method, endpoint, data, headers|
+      assert data =~ /finalize=1/
+    end.respond_with(successful_capture_response)
+  end
   
   private
   


### PR DESCRIPTION
Add the ability to finalize the transaction when doing a partial capture so the transaction doesn't remain open

http://doc.quickpay.dk/api/messagetypes.html#index6h2