### PR TITLE
Translate 'Unsupported' in AVS responses to S

### DIFF
--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -220,11 +220,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def response_object(response)
+        avs_response_code = response[:AVSResultCode]
+        avs_response_code = 'S' if avs_response_code == "Unsupported"
         Response.new(success?(response), response[:Message], response,
           :test => test?,
           :authorization => response[:TransactionNo],
           :fraud_review => fraud_review?(response),
-          :avs_result => { :code => response[:AVSResultCode] },
+          :avs_result => { :code => avs_response_code },
           :cvv_result => response[:CSCResultCode]
         )
       end


### PR DESCRIPTION
@j-mutter @ivanfer for review.

MiGS returns the string "Unsupported" for their AVSResultCode when they don't support AVS. That's not even a code!

This change makes it so that the code gets converted into 'S', which is the code for "Bank does not support AVS" according to [the wikipedia page](http://en.wikipedia.org/wiki/Address_Verification_System).