### PR TITLE
Pay gate ip and email update

### DIFF
--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -194,8 +194,6 @@ module ActiveMerchant #:nodoc:
         SUCCESS_CODES.include?(response[:res])
       end
 
-
-
       def build_request(action, options={})
         xml = Builder::XmlMarkup.new
         xml.instruct!

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -229,7 +229,9 @@ module ActiveMerchant #:nodoc:
           :budp  => 0,
           :amt   => amount(money),
           :cur   => (options[:currency] || currency(money)),
-          :cvv   => creditcard.verification_value
+          :cvv   => creditcard.verification_value,
+          :email => options[:email],
+          :ip    => options[:ip]
         }
       end
 

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -193,7 +193,9 @@ module ActiveMerchant #:nodoc:
       def successful?(response)
         SUCCESS_CODES.include?(response[:res])
       end
-      
+
+
+
       def build_request(action, options={})
         xml = Builder::XmlMarkup.new
         xml.instruct!

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -181,11 +181,20 @@ module ActiveMerchant #:nodoc:
         commit(action, build_request(action, options))
       end
 
+      def refund(money, authorization, options={})
+        action = 'refundtx'
+
+        options.merge!(:money => money, :authorization => authorization)
+        commit(action, build_request(action, options))
+      end
+
       private
 
       def successful?(response)
         SUCCESS_CODES.include?(response[:res])
       end
+
+
 
       def build_request(action, options={})
         xml = Builder::XmlMarkup.new
@@ -201,6 +210,10 @@ module ActiveMerchant #:nodoc:
               money           = options.delete(:money)
               authorization   = options.delete(:authorization)
               build_capture(protocol, money, authorization, options)
+            when 'refundtx'
+              money           = options.delete(:money)
+              authorization   = options.delete(:authorization)
+              build_refund(protocol, money, authorization, options)
           else
             raise "no action specified for build_request"
           end
@@ -225,6 +238,12 @@ module ActiveMerchant #:nodoc:
       def build_capture(xml, money, authorization, options={})
         xml.tag! 'settletx', {
           :tid => authorization
+        }
+      end
+      def build_refund(xml, money, authorization, options={})
+        xml.tag! 'refundtx', {
+          :tid => authorization,
+          :amt => amount(money)
         }
       end
 

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
         action = 'settletx'
 
         options.merge!(:money => money, :authorization => authorization)
-        commit_capture(action, build_request(action, options), authorization)
+        commit(action, build_request(action, options), authorization)
       end
 
       def refund(money, authorization, options={})
@@ -261,22 +261,14 @@ module ActiveMerchant #:nodoc:
         hash
       end
 
-      def commit(action, request)
+      def commit(action, request, authorization = nil)
         response = parse(action, ssl_post(self.live_url, request))
         Response.new(successful?(response), message_from(response), response,
           :test           => test?,
-          :authorization  => response[:tid]
+          :authorization  => authorization ? authorization : response[:tid]
         )
       end
       
-      def commit_capture(action, request, authorization)
-        response = parse(action, ssl_post(self.live_url, request))
-        Response.new(successful?(response), message_from(response), response,
-          :test           => test?,
-          :authorization  => authorization
-        )
-      end
-
       def message_from(response)
         (response[:rdesc] || response[:edesc])
       end

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -193,9 +193,7 @@ module ActiveMerchant #:nodoc:
       def successful?(response)
         SUCCESS_CODES.include?(response[:res])
       end
-
-
-
+      
       def build_request(action, options={})
         xml = Builder::XmlMarkup.new
         xml.instruct!

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -199,9 +199,9 @@ module ActiveMerchant #:nodoc:
         xml.instruct!
 
         xml.tag! 'protocol', :ver => API_VERSION, :pgid => (test? ? TEST_ID : @options[:login]), :pwd => @options[:password] do |protocol|
-          money       = options.delete(:money)
-          authorization   = options.delete(:authorization)
-          creditcard  = options.delete(:creditcard)
+          money         = options.delete(:money)
+          authorization = options.delete(:authorization)
+          creditcard    = options.delete(:creditcard)
           case action
           when 'authtx'
             build_authorization(protocol, money, creditcard, options)

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
         action = 'settletx'
 
         options.merge!(:money => money, :authorization => authorization)
-        commit(action, build_request(action, options))
+        commit_capture(action, authorization, build_request(action, options))
       end
 
       def refund(money, authorization, options={})
@@ -266,6 +266,13 @@ module ActiveMerchant #:nodoc:
         Response.new(successful?(response), message_from(response), response,
           :test           => test?,
           :authorization  => response[:tid]
+        )
+      end
+      def commit_capture(action, authorization, request)
+        response = parse(action, ssl_post(self.live_url, request))
+        Response.new(successful?(response), message_from(response), response,
+          :test           => test?,
+          :authorization  => authorization
         )
       end
 

--- a/test/remote/gateways/remote_pay_gate_xml_test.rb
+++ b/test/remote/gateways/remote_pay_gate_xml_test.rb
@@ -52,4 +52,13 @@ class RemotePayGateXmlTest < Test::Unit::TestCase
     assert_failure response
     assert_equal 'Incorrect Credentials Supplied', response.message
   end
+
+   def test_purchase_and_full_credit
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
+    assert_success credit
+    assert credit.test?
+  end
 end

--- a/test/remote/gateways/remote_pay_gate_xml_test.rb
+++ b/test/remote/gateways/remote_pay_gate_xml_test.rb
@@ -11,6 +11,8 @@ class RemotePayGateXmlTest < Test::Unit::TestCase
     @options = {
       :order_id         => generate_unique_id,
       :billing_address  => address,
+      :email           => 'john.doe@example.com',
+      :ip              => '127.0.0.1',
       :description      => 'Store Purchase',
     }
   end

--- a/test/remote/gateways/remote_pay_gate_xml_test.rb
+++ b/test/remote/gateways/remote_pay_gate_xml_test.rb
@@ -47,15 +47,15 @@ class RemotePayGateXmlTest < Test::Unit::TestCase
 
   def test_invalid_login
     gateway = PayGateXmlGateway.new(
-                :login => '',
-                :password => ''
-              )
+      :login => '',
+      :password => ''
+    )
     assert response = gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'Incorrect Credentials Supplied', response.message
   end
 
-   def test_purchase_and_full_credit
+  def test_successful_purchase_and_refund 
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -7,9 +7,10 @@ class PayGateTest < Test::Unit::TestCase
     @amount = 245000
     @credit_card    = credit_card('4000000000000002')
     @declined_card  = credit_card('4000000000000036')
-
+    
+    # May need to generate a unique order id as server responds with duplicate order detected
     @options = {
-      :order_id         => 'abc123',
+      :order_id         => Time.now.getutc,
       :billing_address  => address,
       :description      => 'Store Purchase',
     }
@@ -46,6 +47,20 @@ class PayGateTest < Test::Unit::TestCase
     assert_success response
 
     assert response.test?
+  end
+
+  def test_purchase_and_full_credit
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+#    We have a problem. The paygate api does not allow you to refund test transactions! As the purchase transaction goes throught correctly
+#    
+#
+#    credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
+#    assert_success credit
+#    assert credit.test?
+
+    
   end
 
 

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -38,6 +38,16 @@ class PayGateTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+
+    assert response = @gateway.refund(@amount, '16996548', @options)
+    assert_instance_of Response, response
+    assert_success response
+
+    assert response.test?
+  end
+
 
   def test_unsuccessful_request
     @gateway.expects(:ssl_post).returns(failed_authorization_response)
@@ -78,6 +88,16 @@ class PayGateTest < Test::Unit::TestCase
     <!DOCTYPE protocol SYSTEM "https://www.paygate.co.za/payxml/payxml_v4.dtd">
     <protocol ver="4.0" pgid="10011021600" pwd="test" >
       <errorrx edesc='Transaction ID Must Only Contain Digits' ecode='9'/>
+    </protocol>
+    ENDOFXML
+  end
+
+  def successful_refund_response
+    <<-ENDOFXML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE protocol SYSTEM "https://www.paygate.co.za/payxml/payxml_v4.dtd">
+    <protocol ver="4.0" pgid="10011021600" pwd="test" >
+      <refundrx tid="16996548" cref="abc123" stat="5" sdesc="Received by Paygate" res="990005" rdesc="Request for Refund Received" bno="" />
     </protocol>
     ENDOFXML
   end

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -12,6 +12,8 @@ class PayGateTest < Test::Unit::TestCase
     @options = {
       :order_id         => Time.now.getutc,
       :billing_address  => address,
+      :email           => 'john.doe@example.com',
+      :ip              => '127.0.0.1',
       :description      => 'Store Purchase',
     }
   end

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -45,7 +45,6 @@ class PayGateTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_refund_response)
 
     assert response = @gateway.refund(@amount, '16996548', @options)
-    assert_instance_of Response, response
     assert_success response
 
     assert response.test?

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -7,9 +7,10 @@ class PayGateTest < Test::Unit::TestCase
     @amount = 245000
     @credit_card    = credit_card('4000000000000002')
     @declined_card  = credit_card('4000000000000036')
-
+    
+    # May need to generate a unique order id as server responds with duplicate order detected
     @options = {
-      :order_id         => 'abc123',
+      :order_id         => Time.now.getutc,
       :billing_address  => address,
       :description      => 'Store Purchase',
     }
@@ -46,6 +47,18 @@ class PayGateTest < Test::Unit::TestCase
     assert_success response
 
     assert response.test?
+  end
+
+  def test_purchase_and_full_credit
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+#    We have a problem. The paygate api does not allow you to refund test transactions! As the purchase transaction goes throught correctly
+#    
+#
+#    credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
+#    assert_success credit
+#    assert credit.test?
   end
 
 

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -7,10 +7,9 @@ class PayGateTest < Test::Unit::TestCase
     @amount = 245000
     @credit_card    = credit_card('4000000000000002')
     @declined_card  = credit_card('4000000000000036')
-    
-    # May need to generate a unique order id as server responds with duplicate order detected
+
     @options = {
-      :order_id         => Time.now.getutc,
+      :order_id         => 'abc123',
       :billing_address  => address,
       :description      => 'Store Purchase',
     }
@@ -47,20 +46,6 @@ class PayGateTest < Test::Unit::TestCase
     assert_success response
 
     assert response.test?
-  end
-
-  def test_purchase_and_full_credit
-    purchase = @gateway.purchase(@amount, @credit_card, @options)
-    assert_success purchase
-
-#    We have a problem. The paygate api does not allow you to refund test transactions! As the purchase transaction goes throught correctly
-#    
-#
-#    credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
-#    assert_success credit
-#    assert credit.test?
-
-    
   end
 
 

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -49,16 +49,6 @@ class PayGateTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_purchase_and_full_credit
-    purchase = @gateway.purchase(@amount, @credit_card, @options)
-    assert_success purchase
-
-    credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
-    assert_success credit
-    assert credit.test?
-  end
-
-
   def test_unsuccessful_request
     @gateway.expects(:ssl_post).returns(failed_authorization_response)
 

--- a/test/unit/gateways/pay_gate_xml_test.rb
+++ b/test/unit/gateways/pay_gate_xml_test.rb
@@ -53,12 +53,9 @@ class PayGateTest < Test::Unit::TestCase
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
-#    We have a problem. The paygate api does not allow you to refund test transactions! As the purchase transaction goes throught correctly
-#    
-#
-#    credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
-#    assert_success credit
-#    assert credit.test?
+    credit = @gateway.refund(@amount, purchase.authorization, :note => 'Sorry')
+    assert_success credit
+    assert credit.test?
   end
 
 


### PR DESCRIPTION
Client requires that payprotect be used in the authtx. I have added this and updated the test cases to include this. Will confirm with paygate on what the behavior is when the email and ip is sent to paygate but not activated on the account.