### PR TITLE
Pathname should be required for non-rails application

### DIFF
--- a/lib/active_merchant/billing/gateways.rb
+++ b/lib/active_merchant/billing/gateways.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 module ActiveMerchant
   module Billing
     load_path = Pathname.new(__FILE__ + '/../../..')


### PR DESCRIPTION
```ruby
require 'activemerchant'
# => NameError: uninitialized constant ActiveMerchant::Billing::Pathname
```
cc @wvanbergen / https://github.com/Shopify/active_merchant/commit/0687ea2b4e7eda10ac621b92850ca1a2e3907c73