### PR TITLE
[MiGS] Return P for CVV results when Unsupported

### DIFF
--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -222,12 +222,16 @@ module ActiveMerchant #:nodoc:
       def response_object(response)
         avs_response_code = response[:AVSResultCode]
         avs_response_code = 'S' if avs_response_code == "Unsupported"
+
+        cvv_result_code = response[:CSCResultCode]
+        cvv_result_code = 'P' if cvv_result_code == "Unsupported"
+
         Response.new(success?(response), response[:Message], response,
           :test => test?,
           :authorization => response[:TransactionNo],
           :fraud_review => fraud_review?(response),
           :avs_result => { :code => avs_response_code },
-          :cvv_result => response[:CSCResultCode]
+          :cvv_result => cvv_result_code
         )
       end
 


### PR DESCRIPTION
@j-mutter @ivanfer for review.

MiGS returns the string "Unsupported" for their CSCResultCode (CVV check) when they don't support doing the check. That's not even a code!

This change makes it so that in that situation the code is translated to be 'P', which according to [this page](http://www.emsecommerce.net/avs_cvv2_response_codes.htm) means "Not Processed".
