### PR TITLE
Authorize.Net: properly send shipping address when provided

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -277,7 +277,11 @@ module ActiveMerchant #:nodoc:
 
         unless shipping_address.blank?
           xml.shipTo do
-            first_name, last_name = names_from(payment_source, shipping_address, options)
+            (first_name, last_name) = if shipping_address[:name]
+              shipping_address[:name].split
+            else
+              [shipping_address[:first_name], shipping_address[:last_name]]
+            end
             xml.firstName(truncate(first_name, 50)) unless empty?(first_name)
             xml.lastName(truncate(last_name, 50)) unless empty?(last_name)
 


### PR DESCRIPTION
The previous version of the code would treat the payment_source as the best source for names - which meant that your credit card's billing name would override your shipping address name.

@aprofeit @ivanfer