### PR TITLE
Add Flo2Cash Simple gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/flo2cash_simple.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_simple.rb
@@ -1,0 +1,190 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class Flo2cashSimpleGateway < Gateway
+      self.display_name = 'Flo2Cash Simple'
+      self.homepage_url = 'http://www.flo2cash.co.nz/'
+
+      self.test_url = 'https://demo.flo2cash.co.nz/ws/paymentws.asmx'
+      self.live_url = 'https://secure.flo2cash.co.nz/ws/paymentws.asmx'
+
+      self.supported_countries = ['NZ']
+      self.default_currency = 'NZD'
+      self.money_format = :dollars
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
+
+      def initialize(options={})
+        requires!(options, :username, :password, :account_id)
+        super
+      end
+
+      def purchase(amount, payment_method, options={})
+        post = {}
+        add_invoice(post, amount, options)
+        add_payment_method(post, payment_method)
+        add_customer_data(post, options)
+
+        commit("purchase", post)
+      end
+
+      def refund(amount, authorization, options={})
+        post = {}
+        add_invoice(post, amount, options)
+        add_reference(post, authorization)
+        add_customer_data(post, options)
+
+        commit("refund", post)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((<Password>)[^<]+(<))i, '\1[FILTERED]\2').
+          gsub(%r((<CardNumber>)[^<]+(<))i, '\1[FILTERED]\2').
+          gsub(%r((<CardCSC>)[^<]+(<))i, '\1[FILTERED]\2')
+      end
+
+      private
+
+      CURRENCY_CODES = Hash.new{|h,k| raise ArgumentError.new("Unsupported currency: #{k}")}
+      CURRENCY_CODES["NZD"] = "554"
+
+      def add_invoice(post, money, options)
+        post[:Amount] = amount(money)
+        post[:Reference] = options[:invoice]
+        post[:Particular] = options[:description]
+      end
+
+      def add_payment_method(post, payment_method)
+        post[:CardNumber] = payment_method.number
+        post[:CardType] = payment_method.brand
+        post[:CardExpiry] = format(payment_method.month, :two_digits) + format(payment_method.year, :two_digits)
+        post[:CardHolderName] = payment_method.name
+        post[:CardCSC] = payment_method.verification_value
+      end
+
+      def add_customer_data(post, options)
+        if(billing_address = (options[:billing_address] || options[:address]))
+          post[:Email] = billing_address[:email]
+        end
+      end
+
+      def add_reference(post, authorization)
+        post[:OriginalTransactionId] = authorization
+      end
+
+      ACTIONS = {
+        "purchase" => "ProcessPurchase",
+        "refund" => "ProcessRefund",
+      }
+
+      def commit(action, post)
+        post[:Username] = @options[:username]
+        post[:Password] = @options[:password]
+        post[:AccountId] = @options[:account_id]
+        process_action = ACTIONS[action] if ACTIONS[action]
+
+        data = build_request(process_action, post)
+        raw = parse(ssl_post(url(action), data, headers(process_action)), process_action)
+
+        succeeded = success_from(raw[:status])
+        Response.new(
+          succeeded,
+          message_from(succeeded, raw),
+          raw,
+          :authorization => authorization_from(action, raw[:transaction_id], post[:OriginalTransactionId]),
+          :error_code => error_code_from(succeeded, raw),
+          :test => test?
+        )
+      end
+
+      def headers(action)
+        {
+          'Content-Type'  => 'application/soap+xml; charset=utf-8',
+          'SOAPAction'    => %{"http://www.flo2cash.co.nz/webservices/paymentwebservice/#{action}"}
+        }
+      end
+
+      def build_request(action, post)
+        xml = Builder::XmlMarkup.new :indent => 2
+        post.each do |field, value|
+          xml.tag!(field, value)
+        end
+        body = xml.target!
+        envelope_wrap(action, body)
+      end
+
+      def envelope_wrap(action, body)
+        <<-EOS
+<?xml version="1.0" encoding="utf-8"?>
+<soap12:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
+  <soap12:Body>
+    <#{action} xmlns="http://www.flo2cash.co.nz/webservices/paymentwebservice">
+      #{body}
+    </#{action}>
+  </soap12:Body>
+</soap12:Envelope>
+        EOS
+      end
+
+      def url(action)
+        (test? ? test_url : live_url)
+      end
+
+      def parse(body, action)
+        response = {}
+        xml = REXML::Document.new(body)
+        root = REXML::XPath.first(xml, "//#{action}Response")
+
+        root.elements.to_a.each do |node|
+          parse_element(response, node)
+        end if root
+
+        response
+      end
+
+      def parse_element(response, node)
+        if node.has_elements?
+          node.elements.each{|element| parse_element(response, element) }
+        else
+          response[node.name.underscore.to_sym] = node.text
+        end
+      end
+
+      def success_from(response)
+        response == 'SUCCESSFUL'
+      end
+
+      def message_from(succeeded, response)
+        if succeeded
+          "Succeeded"
+        else
+          response[:message] || "Unable to read error message"
+        end
+      end
+
+      def authorization_from(action, current, original)
+        # Refunds require the authorization from the authorize() of the MultiResponse.
+        if action == 'capture'
+          original
+        else
+          current
+        end
+      end
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        'Transaction Declined - Expired Card' => STANDARD_ERROR_CODE[:expired_card],
+        'Bank Declined Transaction' => STANDARD_ERROR_CODE[:card_declined],
+        'Insufficient Funds' => STANDARD_ERROR_CODE[:card_declined],
+        'Transaction Declined - Bank Error' => STANDARD_ERROR_CODE[:processing_error],
+        'No Reply from Bank' => STANDARD_ERROR_CODE[:processing_error],
+      }
+
+      def error_code_from(succeeded, response)
+        succeeded ? nil : STANDARD_ERROR_CODE_MAPPING[response[:message]]
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -222,6 +222,11 @@ flo2cash:
   password: ANOTHERCREDENTIAL
   account_id: ANOTHERCREDENTIAL
 
+flo2cash_simple:
+  username: SOMECREDENTIAL
+  password: ANOTHERCREDENTIAL
+  account_id: ANOTHERCREDENTIAL
+
 garanti:
   login: "PROVAUT"
   terminal_id: 111995

--- a/test/remote/gateways/remote_flo2cash_simple_test.rb
+++ b/test/remote/gateways/remote_flo2cash_simple_test.rb
@@ -1,0 +1,73 @@
+require 'test_helper'
+
+class RemoteFlo2cashSimpleTest < Test::Unit::TestCase
+  def setup
+    Base.mode = :test
+
+    @gateway = Flo2cashSimpleGateway.new(fixtures(:flo2cash_simple))
+
+    @amount = 100
+    @credit_card = credit_card('5123456789012346', brand: 'MC', :month => 5, :year => 2017, :verification_value => 111 )
+    @declined_card = credit_card('4000300011112220')
+
+    @options = {
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_invalid_login
+    gateway = Flo2cashSimpleGateway.new(
+      username: 'N/A',
+      password: 'N/A',
+      account_id: '100'
+    )
+    authentication_exception = assert_raise ActiveMerchant::ResponseError, 'Failed with 500 Internal Server Error' do
+      gateway.purchase(@amount, @credit_card, @options)
+    end
+    assert response = authentication_exception.response
+    assert_match(/Authentication error/, response.body)
+  end
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_failed_purchase
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Transaction Declined - Bank Error', response.message
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+  end
+
+  def test_successful_refund
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert refund = @gateway.refund(@amount, response.authorization)
+    assert_success refund
+    assert_equal 'Succeeded', refund.message
+  end
+
+  def test_failed_refund
+    refund_exception = assert_raise ActiveMerchant::ResponseError, 'Failed with 500 Internal Server Error' do
+      @gateway.refund(@amount, '')
+    end
+    assert response = refund_exception.response
+    assert_match(/Original transaction not found/, response.body)
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+end

--- a/test/unit/gateways/flo2cash_simple_test.rb
+++ b/test/unit/gateways/flo2cash_simple_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+class Flo2cashSimpleTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    Base.mode = :test
+
+    @gateway = Flo2cashSimpleGateway.new(
+      :username => 'username',
+      :password => 'password',
+      :account_id => 'account_id'
+    )
+
+    @credit_card = credit_card
+    @amount = 100
+  end
+
+  def test_successful_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal "P150200005007600", response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(failed_purchase_response)
+
+    assert_failure response
+    assert_equal "Transaction Declined - Bank Error", response.message
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+    assert response.test?
+  end
+
+  def test_successful_refund
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal "P150200005007600", response.authorization
+
+    refund = stub_comms do
+      @gateway.refund(@amount, response.authorization)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/P150200005007600/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
+  def test_empty_response_fails
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(empty_purchase_response)
+
+    assert_failure response
+    assert_equal "Unable to read error message", response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript =  @gateway.scrub(successful_purchase_response)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+  private
+
+  def successful_purchase_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessPurchaseResponse xmlns=\"http://www.flo2cash.co.nz/webservices/paymentwebservice\"><transactionresult><TransactionId>P150200005007600</TransactionId><OriginalTransactionId /><Type>PURCHASE</Type><AccountId>621366</AccountId><Status>SUCCESSFUL</Status><ReceiptNumber>25002185</ReceiptNumber><AuthCode>088682</AuthCode><Amount>1.00</Amount><Reference /><Particular>Store Purchase</Particular><Message>Transaction Successful</Message><BlockedReason /><CardStored>false</CardStored><CardToken /></transactionresult></ProcessPurchaseResponse></soap:Body></soap:Envelope>
+    )
+  end
+
+  def failed_purchase_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessPurchaseResponse xmlns=\"http://www.flo2cash.co.nz/webservices/paymentwebservice\"><transactionresult><TransactionId>P150200005007599</TransactionId><OriginalTransactionId /><Type>PURCHASE</Type><AccountId>621366</AccountId><Status>FAILED</Status><ReceiptNumber>0</ReceiptNumber><AuthCode /><Amount>1.00</Amount><Reference /><Particular>Store Purchase</Particular><Message>Transaction Declined - Bank Error</Message><BlockedReason /><CardStored>false</CardStored><CardToken /></transactionresult></ProcessPurchaseResponse></soap:Body></soap:Envelope>
+    )
+  end
+
+  def successful_refund_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessRefundResponse xmlns=\"http://www.flo2cash.co.nz/webservices/paymentwebservice\"><transactionresult><TransactionId>P150200005007602</TransactionId><OriginalTransactionId>P150200005007601</OriginalTransactionId><Type>REFUND</Type><AccountId>621366</AccountId><Status>SUCCESSFUL</Status><ReceiptNumber>25002187</ReceiptNumber><AuthCode>039335</AuthCode><Amount>1.00</Amount><Reference /><Particular /><Message>Transaction Successful</Message><BlockedReason /><CardStored>false</CardStored><CardToken /></transactionresult></ProcessRefundResponse></soap:Body></soap:Envelope>
+    )
+  end
+
+  def empty_purchase_response
+    %(
+    )
+  end
+end


### PR DESCRIPTION
This is a separate adapter that support Flo2Cash's native account types.
The other 'flo2cash' is designed for full merchant bank accounts.