### PR TITLE
Adds apple pay support for FirstData E4

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -211,9 +211,28 @@ module ActiveMerchant #:nodoc:
           xml.tag! "VerificationStr1", address_values.join("|")
         end
 
-        if credit_card.verification_value?
+        if credit_card.is_a?(NetworkTokenizationCreditCard)
+          add_network_tokenization_credit_card(xml, credit_card)
+        elsif credit_card.verification_value?
           xml.tag! "CVD_Presence_Ind", "1"
           xml.tag! "VerificationStr2", credit_card.verification_value
+        end
+      end
+
+      def add_network_tokenization_credit_card(xml, credit_card)
+        xml.tag!("Ecommerce_Flag", credit_card.eci)
+
+        case card_brand(credit_card).to_sym
+        when :visa
+          xml.tag!("XID", credit_card.transaction_id) if credit_card.transaction_id
+          xml.tag!("CAVV", credit_card.payment_cryptogram)
+        when :mastercard
+          xml.tag!("XID", credit_card.transaction_id) if credit_card.transaction_id
+          xml.tag!("CAVV", credit_card.payment_cryptogram)
+        when :american_express
+          cryptogram = Base64.decode64(credit_card.payment_cryptogram)
+          xml.tag!("XID", Base64.encode64(cryptogram[20...40]))
+          xml.tag!("CAVV", Base64.encode64(cryptogram[0...20]))
         end
       end
 

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -128,6 +128,57 @@ class FirstdataE4Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_network_tokenization_requests_with_visa
+    stub_comms do
+      credit_card = network_tokenization_credit_card('4111111111111111',
+        :brand              => 'visa',
+        :transaction_id     => "123",
+        :eci                => "05",
+        :payment_cryptogram => "111111111100cryptogram"
+      )
+
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match "<Ecommerce_Flag>05</Ecommerce_Flag>", data
+      assert_match "<XID>123</XID>", data
+      assert_match "<CAVV>111111111100cryptogram</CAVV>", data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_network_tokenization_requests_with_mastercard
+    stub_comms do
+      credit_card = network_tokenization_credit_card('5555555555554444',
+        :brand              => 'mastercard',
+        :transaction_id     => "123",
+        :eci                => "05",
+        :payment_cryptogram => "111111111100cryptogram"
+      )
+
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match "<Ecommerce_Flag>05</Ecommerce_Flag>", data
+      assert_match "<XID>123</XID>", data
+      assert_match "<CAVV>111111111100cryptogram</CAVV>", data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_network_tokenization_requests_with_amex
+    stub_comms do
+      credit_card = network_tokenization_credit_card('378282246310005',
+        :brand              => 'american_express',
+        :transaction_id     => "123",
+        :eci                => "05",
+        :payment_cryptogram => Base64.encode64("111111111100cryptogram")
+      )
+
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_match "<Ecommerce_Flag>05</Ecommerce_Flag>", data
+      assert_match "<XID>YW0=\n</XID>", data
+      assert_match "<CAVV>MTExMTExMTExMTAwY3J5cHRvZ3I=\n</CAVV>", data
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_requests_include_card_authentication_data
     authentication_hash = {
       eci: "06",


### PR DESCRIPTION
Another continuation of https://github.com/Shopify/active_merchant/pull/1566 for FirstData E4.

There's no way to test this without doing a live test (they don't have sandbox verification for it). I definite confirmation from FirstData that this is the format they expect this data in and that it will work without issue.

This can be merged as soon as https://github.com/Shopify/active_merchant/pull/1566 in in.

@girasquid @bizla for review please, thanks!

cc @markabe @rwdaigle @ntalbott