### PR TITLE
Flo2Cash: Map Reference->:order_id (not :invoice)

### DIFF
--- a/lib/active_merchant/billing/gateways/flo2cash.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash.rb
@@ -69,7 +69,7 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, money, options)
         post[:Amount] = amount(money)
-        post[:Reference] = options[:invoice]
+        post[:Reference] = options[:order_id]
         post[:Particular] = options[:description]
       end
 

--- a/lib/active_merchant/billing/gateways/flo2cash_simple.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_simple.rb
@@ -53,7 +53,7 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, money, options)
         post[:Amount] = amount(money)
-        post[:Reference] = options[:invoice]
+        post[:Reference] = options[:order_id]
         post[:Particular] = options[:description]
       end
 

--- a/test/unit/gateways/flo2cash_simple_test.rb
+++ b/test/unit/gateways/flo2cash_simple_test.rb
@@ -18,7 +18,9 @@ class Flo2cashSimpleTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card)
+      @gateway.purchase(@amount, @credit_card, order_id: "boom")
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<Reference>boom</Reference>}, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response

--- a/test/unit/gateways/flo2cash_test.rb
+++ b/test/unit/gateways/flo2cash_test.rb
@@ -18,7 +18,9 @@ class Flo2cashTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card)
+      @gateway.purchase(@amount, @credit_card, order_id: "boom")
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r{<Reference>boom</Reference>}, data)
     end.respond_with(successful_authorize_response, successful_capture_response)
 
     assert_success response


### PR DESCRIPTION
:invoice is actually rarely used, and :order_id is preferred when
possible.

This will break anyone who is using :invoice with Flo2Cash since
:invoice wouldn't get mapped anymore, but since the adapter is new
seems worth the possible breakage.

@duff @markabe please review.