### PR TITLE
Remove Ruby 1.9 from travis.yml as it is no longer supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
 - "2.2"
 - "2.1"
 - "2.0"
-- "1.9"
 
 gemfile:
 - Gemfile.rails32

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Netbilling: Add store support [cshepherd]
 * Add Qvalent gateway [markabe]
 * Expose proxy address and port to gateways [arkes]
+* Remove Ruby 1.9 [j-mutter]
 
 == Version 1.47.0 (February 25, 2015)
 


### PR DESCRIPTION
Alright, we're no longer building for ruby 1.9 on Travis. Opinions on *enforcing* 2.0+?

@girasquid @ntalbott @wvanbergen 