### PR TITLE
Missing parenthesis in Qvalent remote test

### DIFF
--- a/test/remote/gateways/remote_qvalent_test.rb
+++ b/test/remote/gateways/remote_qvalent_test.rb
@@ -26,7 +26,7 @@ class RemoteQvalentTest < Test::Unit::TestCase
       gateway.purchase(@amount, @credit_card, @options)
     end
     response = authentication_exception.response
-    assert_match %r{Error 403: Missing authentication}, response.body)
+    assert_match(%r{Error 403: Missing authentication}, response.body)
   end
 
   def test_successful_purchase


### PR DESCRIPTION
Due to IP whitelist restrictions, Nathaniel couldn't run remote tests
after doing some cleanup.

@ntalbott Just missed one paren :smile: 