### PR TITLE
Qvalent: Do not sent order.ipAddress when storing card

### DIFF
--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -41,7 +41,6 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_payment_method(post, payment_method)
         add_card_reference(post)
-        add_customer_data(post, options)
 
         commit("registerAccount", post)
       end


### PR DESCRIPTION
The 'store' action does not accept order.ipAddress. The test system
allowed it but caused this error in production.

> Card retain/store failed with error: Invalid Parameters - order.ipAddress: Field is not allowed for this type of request

Remote tests results:
8 tests, 22 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed