### PR TITLE
Improve Quickbooks transcript scrubbing regex

### DIFF
--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -104,8 +104,8 @@ module ActiveMerchant #:nodoc:
           gsub(%r((oauth_nonce=\")\w+), '\1[FILTERED]').
           gsub(%r((oauth_signature=\")[a-zA-Z%0-9]+), '\1[FILTERED]').
           gsub(%r((oauth_token=\")\w+), '\1[FILTERED]').
-          gsub(%r((\"card\":{\"number\":\")\d+), '\1[FILTERED]').
-          gsub(%r((\"cvc\":\")\d+), '\1[FILTERED]')
+          gsub(%r((number\D+)\d{16}), '\1[FILTERED]').
+          gsub(%r((cvc\D+)\d{3}), '\1[FILTERED]')
       end
 
       private

--- a/test/unit/gateways/quickbooks_test.rb
+++ b/test/unit/gateways/quickbooks_test.rb
@@ -108,7 +108,19 @@ class QuickBooksTest < Test::Unit::TestCase
     assert_equal @gateway.send(:scrub, pre_scrubbed), post_scrubbed
   end
 
+  def test_scrub_with_small_json
+    assert_equal @gateway.scrub(pre_scrubbed_small_json), post_scrubbed_small_json
+  end
+
   private
+
+  def pre_scrubbed_small_json
+    "intuit.com\\r\\nContent-Length: 258\\r\\n\\r\\n\"\n<- \"{\\\"amount\\\":\\\"34.50\\\",\\\"currency\\\":\\\"USD\\\",\\\"card\\\":{\\\"number\\\":\\\"4111111111111111\\\",\\\"expMonth\\\":\\\"09\\\",\\\"expYear\\\":2016,\\\"cvc\\\":\\\"123\\\",\\\"name\\\":\\\"Bob Bobson\\\",\\\"address\\\":{\\\"streetAddress\\\":null,\\\"city\\\":\\\"Los Santos\\\",\\\"region\\\":\\\"CA\\\",\\\"country\\\":\\\"US\\\",\\\"postalCode\\\":\\\"90210\\\"}},\\\"capture\\\":\\\"true\\\"}\"\n-> \"HTTP/1.1 201 Created\\r\\n\"\n-> \"Date: Tue, 03 Mar 2015 20:00:35 GMT\\r\\n\"\n-> \"Content-Type: "
+  end
+
+  def post_scrubbed_small_json
+    "intuit.com\\r\\nContent-Length: 258\\r\\n\\r\\n\"\n<- \"{\\\"amount\\\":\\\"34.50\\\",\\\"currency\\\":\\\"USD\\\",\\\"card\\\":{\\\"number\\\":\\\"[FILTERED]\\\",\\\"expMonth\\\":\\\"09\\\",\\\"expYear\\\":2016,\\\"cvc\\\":\\\"[FILTERED]\\\",\\\"name\\\":\\\"Bob Bobson\\\",\\\"address\\\":{\\\"streetAddress\\\":null,\\\"city\\\":\\\"Los Santos\\\",\\\"region\\\":\\\"CA\\\",\\\"country\\\":\\\"US\\\",\\\"postalCode\\\":\\\"90210\\\"}},\\\"capture\\\":\\\"true\\\"}\"\n-> \"HTTP/1.1 201 Created\\r\\n\"\n-> \"Date: Tue, 03 Mar 2015 20:00:35 GMT\\r\\n\"\n-> \"Content-Type: "
+  end
 
   def successful_purchase_response
     <<-RESPONSE


### PR DESCRIPTION
The original regex was a bit too firm about the structure of the fields; this updates it to handle a card number being immediately after the word "number", and a CVC being immediately after the word "cvc".

@j-mutter @jnormore for review.