### PR TITLE
Name/verification fields are optional with network tokenization

### DIFF
--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -1,16 +1,24 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class NetworkTokenizationCreditCard < CreditCard
-      # A +NetworkTokenizationCreditCard+ object represents a tokenized credit card 
+      # A +NetworkTokenizationCreditCard+ object represents a tokenized credit card
       # using the EMV Network Tokenization specification, http://www.emvco.com/specifications.aspx?id=263.
       #
-      # It includes all fields of the +CreditCard+ class with additional fields for 
+      # It includes all fields of the +CreditCard+ class with additional fields for
       # verification data that must be given to gateways through existing fields (3DS / EMV).
       #
-      # The only tested usage of this at the moment is with an Apple Pay decrypted PKPaymentToken, 
-      # https://developer.apple.com/library/ios/documentation/PassKit/Reference/PaymentTokenJSON/PaymentTokenJSON.html 
+      # The only tested usage of this at the moment is with an Apple Pay decrypted PKPaymentToken,
+      # https://developer.apple.com/library/ios/documentation/PassKit/Reference/PaymentTokenJSON/PaymentTokenJSON.html
+
+      # These are not relevant (verification) or optional (name) for Apple Pay
+      self.require_verification_value = false
+      self.require_name = false
 
       attr_accessor :payment_cryptogram, :eci, :transaction_id
+
+      def type
+        "network_tokenization"
+      end
     end
   end
 end

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
+
+  def setup
+    @tokenized_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+      number: "4242424242424242", :brand => "visa",
+      month: default_expiration_date.month, year: default_expiration_date.year,
+      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=", eci: "05"
+    })
+  end
+
+  def test_type
+    assert_equal "network_tokenization", @tokenized_card.type
+  end
+
+  def test_optional_validations
+    assert @tokenized_card.valid?, "Network tokenization card should not require name or verification value"
+  end
+end


### PR DESCRIPTION
Some network tokenization implementations, specifically Apple Pay, do not
provide, or make optional, the name and verification value fields.
NetworkTokenizationCreditCard should not require these fields.

Does this look sane, @jnormore?