### PR TITLE
check status field on responses from the gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -242,11 +242,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def success?(response)
-        response['errors'].present? ? FRAUD_WARNING_CODES.concat(['0']).include?(response['errors'].first['code']) : true
+      return FRAUD_WARNING_CODES.concat(['0']).include?(response['errors'].first['code']) if response['errors']
+        
+      !['DECLINED', 'CANCELLED'].include?(response['status'])
       end
 
       def message_from(response)
-        response['errors'].present? ? response["errors"].map {|error_hash| error_hash["message"] }.join(" ") : "Transaction Approved"
+        response['errors'].present? ? response["errors"].map {|error_hash| error_hash["message"] }.join(" ") : response['status']
       end
 
       def errors_from(response)

--- a/test/remote/gateways/remote_quickbooks_test.rb
+++ b/test/remote/gateways/remote_quickbooks_test.rb
@@ -22,7 +22,7 @@ class RemoteTest < Test::Unit::TestCase
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
-    assert_equal 'Transaction Approved', response.message
+    assert_equal 'CAPTURED', response.message
   end
 
   def test_failed_purchase
@@ -83,7 +83,7 @@ class RemoteTest < Test::Unit::TestCase
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response
-    assert_match %r{Transaction Approved}, response.message
+    assert_match %r{AUTHORIZED}, response.message
   end
 
   def test_failed_verify


### PR DESCRIPTION
A declined transaction on `QuickBooks` gateway assumed that there would always be an error object in the response - sometimes there are not. 

@girasquid