### PR TITLE
Fix a simple argument typo in Qvalent add_reference

### DIFF
--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
         post["customer.customerReferenceNumber"] = options[:order_id]
       end
 
-      def add_reference(post, authorization, opions)
+      def add_reference(post, authorization, options)
         post["customer.originalOrderNumber"] = authorization
         add_order_number(post, options)
       end


### PR DESCRIPTION
The method had an argument that contained a simple typo, `opions` instead of `options`.