### PR TITLE
Add standard error codes for auth.net

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -16,6 +16,25 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.authorize.net/'
       self.display_name = 'Authorize.Net'
 
+      STANDARD_ERROR_CODE_MAPPING = {
+        '36' => STANDARD_ERROR_CODE[:incorrect_number],
+        '237' => STANDARD_ERROR_CODE[:invalid_number],
+        '2315' => STANDARD_ERROR_CODE[:invalid_number],
+        '37' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        '2316' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        '378' => STANDARD_ERROR_CODE[:invalid_cvc],     
+        '38' => STANDARD_ERROR_CODE[:expired_card],
+        '2317' => STANDARD_ERROR_CODE[:expired_card],
+        '244' => STANDARD_ERROR_CODE[:incorrect_cvc],
+        '227' => STANDARD_ERROR_CODE[:incorrect_address],
+        '2127' => STANDARD_ERROR_CODE[:incorrect_address],
+        '22' => STANDARD_ERROR_CODE[:card_declined],
+        '23' => STANDARD_ERROR_CODE[:card_declined],
+        '3153' => STANDARD_ERROR_CODE[:processing_error],
+        '235' => STANDARD_ERROR_CODE[:processing_error],
+        '24' => STANDARD_ERROR_CODE[:pickup_card]
+      }
+
       class_attribute :duplicate_window
 
       APPROVED, DECLINED, ERROR, FRAUD_REVIEW = 1, 2, 3, 4
@@ -339,7 +358,8 @@ module ActiveMerchant #:nodoc:
             test: test?,
             avs_result: avs_result,
             cvv_result: cvv_result,
-            fraud_review: fraud_review?(response)
+            fraud_review: fraud_review?(response),
+            error_code: map_error_code(response[:response_code], response[:response_reason_code])
           )
         end
       end
@@ -450,6 +470,10 @@ module ActiveMerchant #:nodoc:
 
       def using_live_gateway_in_test_mode?(response)
         !test? && response[:test_request] == "1"
+      end
+
+      def map_error_code(response_code, response_reason_code)
+        STANDARD_ERROR_CODE_MAPPING[response_code.to_s << response_reason_code.to_s]
       end
     end
   end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -38,6 +38,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 'The credit card number is invalid', response.message
+    assert_equal 'incorrect_number', response.error_code
   end
 
   def test_successful_echeck_purchase
@@ -61,6 +62,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_failure response
     assert response.test?
     assert_equal 'The credit card has expired', response.message
+    assert_equal 'expired_card', response.error_code
   end
 
   def test_successful_authorize_and_capture
@@ -150,12 +152,14 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, apple_pay_payment_token(payment_data: {data: 'garbage'}), @options)
     assert_failure response
     assert_equal 'There was an error processing the payment data', response.message
+    assert_equal 'processing_error', response.error_code
   end
 
   def test_failed_apple_pay_purchase
     response = @gateway.purchase(@amount, apple_pay_payment_token(payment_data: {data: 'garbage'}), @options)
     assert_failure response
     assert_equal 'There was an error processing the payment data', response.message
+    assert_equal 'processing_error', response.error_code
   end
 
   def test_card_present_purchase_with_track_data_only

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -221,6 +221,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
+    assert_equal 'incorrect_number', response.error_code
   end
 
   def test_live_gateway_cannot_use_test_mode_on_auth_dot_net_server
@@ -250,6 +251,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
+    assert_equal 'incorrect_number', response.error_code
   end
 
   def test_successful_capture
@@ -257,6 +259,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     capture = @gateway.capture(@amount, '2214269051#XXXX1234', @options)
     assert_success capture
+    assert_equal nil, capture.error_code
   end
 
   def test_failed_capture


### PR DESCRIPTION
Added applicable authorize.net error codes defined [here](http://www.authorize.net/support/ReportingGuide_XML.pdf).

@j-mutter @aprofeit for review


@ntalbott