### PR TITLE
JetPay REVERSEAUTH functionality

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Qvalent: Fix scrub replacement, it was too greedy [markabe]
 * PayConex: Add gateway [duff]
 * AuthorizeNet: Add credit support [duff]
+* JetPay: Add REVERSEAUTH support to void [brokenbeatnik]
 
 == Version 1.47.0 (February 25, 2015)
 

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -81,7 +81,12 @@ module ActiveMerchant #:nodoc:
 
       def void(reference, options = {})
         transaction_id, approval, amount = reference.split(";")
-        commit(amount.to_i, build_void_request(amount.to_i, transaction_id, approval))
+        if (options[:reverseauth] == true)
+          request = build_reverseauth_request(amount.to_i, transaction_id, approval, options[:credit_card]) 
+        else
+          request = build_void_request(amount.to_i, transaction_id, approval)
+        end
+        commit(amount.to_i, request)
       end
 
       def credit(money, transaction_id_or_card, options = {})
@@ -151,6 +156,16 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'Approval', approval
           xml.tag! 'TotalAmount', amount(money)
 
+          xml.target!
+        end
+      end
+      
+      def build_reverseauth_request(money, transaction_id, approval, card)
+        build_xml_request('REVERSEAUTH', transaction_id) do |xml|
+          add_credit_card(xml, card)
+          xml.tag! 'Approval', approval
+          xml.tag! 'TotalAmount', amount(money)
+          
           xml.target!
         end
       end

--- a/test/remote/gateways/remote_jetpay_test.rb
+++ b/test/remote/gateways/remote_jetpay_test.rb
@@ -44,13 +44,28 @@ class RemoteJetpayTest < Test::Unit::TestCase
     assert_success capture
   end
   
-  def test_void
-    # must void a valid auth
+  def test_reverseauth
+    #Use void with special flag to reverseauth instead of void
     assert auth = @gateway.authorize(9900, @credit_card, @options)
     assert_success auth
     assert_equal 'APPROVED', auth.message
     assert_not_nil auth.authorization
     assert_not_nil auth.params["approval"]
+
+    assert void = @gateway.void(auth.authorization, {reverseauth: true, credit_card: @credit_card})
+    assert_success void
+  end
+  
+  def test_void
+    # must void a valid capture
+    assert auth = @gateway.authorize(9900, @credit_card, @options)
+    assert_success auth
+    assert_equal 'APPROVED', auth.message
+    assert_not_nil auth.authorization
+    assert_not_nil auth.params["approval"]
+
+    assert capture = @gateway.capture(9900, auth.authorization)
+    assert_success capture
     
     assert void = @gateway.void(auth.authorization)
     assert_success void

--- a/test/unit/gateways/jetpay_test.rb
+++ b/test/unit/gateways/jetpay_test.rb
@@ -55,7 +55,7 @@ class JetpayTest < Test::Unit::TestCase
   def test_successful_reverseauth
     @gateway.expects(:ssl_post).returns(successful_reverseauth_response)
     
-    assert response = @gateway.void('010327153017T10018;502F6B;100', {reverseauth: true})
+    assert response = @gateway.void('010327153017T10018;502F6B;100', {reverseauth: true, credit_card: credit_card('4242424242424242')})
     assert_success response
       
     assert_equal('010327153017T10018;502F6B;100', response.authorization)

--- a/test/unit/gateways/jetpay_test.rb
+++ b/test/unit/gateways/jetpay_test.rb
@@ -51,6 +51,17 @@ class JetpayTest < Test::Unit::TestCase
     assert_equal('502F6B', response.params["approval"])
     assert response.test?
   end
+  
+  def test_successful_reverseauth
+    @gateway.expects(:ssl_post).returns(successful_reverseauth_response)
+    
+    assert response = @gateway.void('010327153017T10018;502F6B;100', {reverseauth: true})
+    assert_success response
+      
+    assert_equal('010327153017T10018;502F6B;100', response.authorization)
+    assert_equal('502F6B', response.params["approval"])
+    assert response.test?
+  end
 
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
@@ -164,6 +175,17 @@ class JetpayTest < Test::Unit::TestCase
         <Approval>502F6B</Approval>
         <ResponseText>APPROVED</ResponseText>
       </JetPayResponse>
+    EOF
+  end
+  
+  def successful_reverseauth_response
+    <<-EOF
+      <JetPayResponse>
+        <TransactionID>010327153017T10018</TransactionID>
+        <ActionCode>000</ActionCode>
+        <Approval>502F6B</Approval>
+        <ResponseText>VAPPROVED</ResponseText>
+      </JetPayResponse>    
     EOF
   end
 


### PR DESCRIPTION
Added proposed reverseauth options to void request for JetPay, which distinguishes between voiding an auth and voiding a capture. Fixed previously broken test case. Closes shopify/active_merchant#1606.

This was spurred by an customer using JetPay with a workflow that required them to be able to void an auth. The void method as implemented voided a capture but not an auth, and would return an error if you attempted to void the auth. Per the XML Specification at https://www.jetpay.com/resources/library/pdf/xml/JetPay_XML_Specification-20120216.pdf, a REVERSEAUTH request (section 3.6, p. 16) must be submitted to complete this. Since there is only one void method, the reverseauth flag and the credit card number are sent in through the options hash. If the flag :reverseauth is set to true, the credit card is used and a REVERSEAUTH is submitted. If not, the VOID request is submitted as before. 

I added a test case for the remote_jetpay_test and ensured it passed. It appears the VOID test was failing, so I made it capture before attempting a proper VOID. 