### PR TITLE
Adding standard error codes for firstdata

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -40,6 +40,27 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = "http://www.firstdata.com"
       self.display_name = "FirstData Global Gateway e4"
 
+      STANDARD_ERROR_CODE_MAPPING = {
+      # Bank error codes: https://firstdata.zendesk.com/entries/471297-First-Data-Global-Gateway-e4-Bank-Response-Codes
+        '201' => STANDARD_ERROR_CODE[:incorrect_number],
+        '531' => STANDARD_ERROR_CODE[:invalid_cvc],
+        '503' => STANDARD_ERROR_CODE[:invalid_cvc],
+        '811' => STANDARD_ERROR_CODE[:invalid_cvc],
+        '605' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        '522' => STANDARD_ERROR_CODE[:expired_card],
+        '303' => STANDARD_ERROR_CODE[:card_declined],
+        '530' => STANDARD_ERROR_CODE[:card_declined],
+        '401' => STANDARD_ERROR_CODE[:call_issuer],
+        '402' => STANDARD_ERROR_CODE[:call_issuer],
+        '501' => STANDARD_ERROR_CODE[:pickup_card],
+      # Ecommerce error codes -- https://firstdata.zendesk.com/entries/451980-ecommerce-response-codes-etg-codes
+        '22' => STANDARD_ERROR_CODE[:invalid_number],
+        '25' => STANDARD_ERROR_CODE[:invalid_expiry_date],
+        '31' => STANDARD_ERROR_CODE[:incorrect_cvc],
+        '44' => STANDARD_ERROR_CODE[:incorrect_zip],
+        '42' => STANDARD_ERROR_CODE[:processing_error]
+      }
+
       # Create a new FirstdataE4Gateway
       #
       # The gateway requires that a valid login and password be passed
@@ -277,7 +298,8 @@ module ActiveMerchant #:nodoc:
           :test => test?,
           :authorization => successful?(response) ? response_authorization(action, response, credit_card) : '',
           :avs_result => {:code => response[:avs]},
-          :cvv_result => response[:cvv2]
+          :cvv_result => response[:cvv2],
+          :error_code => standard_error_code(response)
         )
       end
 
@@ -341,8 +363,13 @@ module ActiveMerchant #:nodoc:
         {
           :transaction_approved => "false",
           :error_number => error.code,
-          :error_description => error.body
+          :error_description => error.body,
+          :ecommerce_error_code => error.body.gsub(/[^\d]/, '')
         }
+      end
+
+      def standard_error_code(response)
+        STANDARD_ERROR_CODE_MAPPING[response[:bank_resp_code] || response[:ecommerce_error_code]]
       end
 
       def parse(xml)

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -51,6 +51,7 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @bad_credit_card, @options)
     assert_match(/Invalid Credit Card/, response.message)
     assert_failure response
+    assert_equal response.error_code, "invalid_number"
   end
 
   def test_trans_error
@@ -59,6 +60,7 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options )
     assert_match(/Unable to Send Transaction/, response.message) # 42 is 'unable to send trans'
     assert_failure response
+    assert_equal response.error_code, "processing_error"
   end
 
   def test_purchase_and_credit
@@ -104,6 +106,7 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
     assert response = @gateway.verify(@bad_credit_card, @options)
     assert_failure response
     assert_match %r{Invalid Credit Card Number}, response.message
+    assert_equal response.error_code, "invalid_number"
   end
 
   def test_invalid_login

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -79,6 +79,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_failure response
+    assert_equal response.error_code, "invalid_expiry_date"
   end
 
   def test_successful_verify


### PR DESCRIPTION
Adding standard error codes for First Data. Did my best to fit standard error codes into their model. Note I was not able to find a response parameter that contained only the ecommerce error code so I am extracting it out of the response message. 

Bank codes: https://firstdata.zendesk.com/entries/471297-First-Data-Global-Gateway-e4-Bank-Response-Codes
Ecommerce codes: https://firstdata.zendesk.com/entries/451980-ecommerce-response-codes-etg-codes

@j-mutter @aprofeit 