### PR TITLE
Add network tokenization support for auth.net

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * Add Monei.net gateway [leolara]
 * MerchantWarrior: Fix refund and capture signatures [duff]
 * CenPOS: Add support for capture and refund [markabe]
+* Authorize.net: Add support for network tokenization credit cards [jnormore]
 
 == Version 1.47.0 (February 25, 2015)
 

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -237,6 +237,9 @@ module ActiveMerchant #:nodoc:
               unless empty?(credit_card.verification_value)
                 xml.cardCode(credit_card.verification_value)
               end
+              if credit_card.is_a?(NetworkTokenizationCreditCard)
+                xml.cryptogram(credit_card.payment_cryptogram)
+              end
             end
           end
         end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -301,6 +301,19 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     # dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
   end
 
+  def test_successful_authorize_and_capture_with_network_tokenization
+    credit_card = network_tokenization_credit_card('4000100011112224',
+      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      verification_value: nil
+    )
+    auth = @gateway.authorize(@amount, credit_card, @options)
+    assert_success auth
+    assert_equal 'This transaction has been approved', auth.message
+
+    capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+  end
+
   private
 
   def apple_pay_payment_token(options = {})


### PR DESCRIPTION
Docs: http://developer.authorize.net/api/reference/#payment-transactions-charge-a-tokenized-credit-card

@bizla @j-mutter @rwdaigle for review please, thanks!