### PR TITLE
CenPOS: Map InvoiceDetail field

### DIFF
--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -115,6 +115,7 @@ module ActiveMerchant #:nodoc:
         post[:CurrencyCode] = CURRENCY_CODES[options[:currency] || currency(money)]
         post[:TaxAmount] = amount(options[:tax])
         post[:InvoiceNumber] = options[:order_id]
+        post[:InvoiceDetail] = options[:description]
       end
 
       def add_payment_method(post, payment_method)

--- a/test/remote/gateways/remote_cenpos_test.rb
+++ b/test/remote/gateways/remote_cenpos_test.rb
@@ -28,7 +28,7 @@ class RemoteCenposTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    response = @gateway.purchase(@amount, @credit_card, @options)
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(description: "<xml><description/></xml>"))
     assert_success response
     assert_equal "Succeeded", response.message
   end


### PR DESCRIPTION
@duff I misread the documentation before and thought that passing the
InvoiceDetail required a different TransactionType, making it
incompatible. Turns out to be untrue.