### PR TITLE
Send amount in Pin Payments capture requests

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -62,7 +62,7 @@ module ActiveMerchant #:nodoc:
       # Captures a previously authorized charge. Capturing only part of the original
       # authorization is currently not supported.
       def capture(money, token, options = {})
-        commit(:put, "charges/#{CGI.escape(token)}/capture", {}, options)
+        commit(:put, "charges/#{CGI.escape(token)}/capture", { :amount => amount(money) }, options)
       end
 
       # Updates the credit card for the customer.

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
         purchase(money, creditcard, options)
       end
 
-      # Captures a previously authorized charge. Capturing a certin amount of the original
+      # Captures a previously authorized charge. Capturing only part of the original
       # authorization is currently not supported.
       def capture(money, token, options = {})
         commit(:put, "charges/#{CGI.escape(token)}/capture", {}, options)

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -39,7 +39,7 @@ class RemotePinTest < Test::Unit::TestCase
     assert_failure response
   end
 
-  def test_failed_capture
+  def test_failed_capture_due_to_invalid_token
     response = @gateway.capture(@amount, "bogus", @options)
     assert_failure response
   end

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -44,6 +44,16 @@ class RemotePinTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failed_capture_due_to_invalid_amount
+    authorization = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorization
+    assert_equal authorization.params['response']['captured'], false
+
+    response = @gateway.capture(@amount - 1, authorization.authorization, @options)
+    assert_failure response
+    assert_equal 'invalid_capture_amount', response.params['error']
+  end
+
   def test_successful_purchase_without_description
     @options.delete(:description)
     response = @gateway.purchase(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -21,17 +21,17 @@ class RemotePinTest < Test::Unit::TestCase
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
-    assert_equal response.params['response']['captured'], true
+    assert_equal true, response.params['response']['captured']
   end
 
   def test_successful_authorize_and_capture
     authorization = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorization
-    assert_equal authorization.params['response']['captured'], false
+    assert_equal false, authorization.params['response']['captured']
 
     response = @gateway.capture(@amount, authorization.authorization, @options)
     assert_success response
-    assert_equal response.params['response']['captured'], true
+    assert_equal true, response.params['response']['captured']
   end
 
   def test_failed_authorize
@@ -110,12 +110,12 @@ class RemotePinTest < Test::Unit::TestCase
     response = @gateway.store(@credit_card, @options)
     assert_success response
     assert_not_nil response.authorization
-    assert_equal response.params['response']['card']['expiry_year'], @credit_card.year
+    assert_equal @credit_card.year, response.params['response']['card']['expiry_year']
 
     response = @gateway.update(response.authorization, @visa_credit_card, :address => address)
     assert_success response
     assert_not_nil response.authorization
-    assert_equal response.params['response']['card']['expiry_year'], @visa_credit_card.year
+    assert_equal @visa_credit_card.year, response.params['response']['card']['expiry_year']
   end
 
   def test_refund


### PR DESCRIPTION
## Summary

This changes the Pin Payments gateway class so that capture requests will send the amount. Pin Payments does not support partial captures, so currently if an Active Merchant user attempts to capture less than the originally-authorised amount, Pin Payments will capture the _full_ amount and report success. With the changes in this pull request, attempts to capture less than the originally-authorised amount will fail.

## Details

Active Merchant includes a gateway class for Pin Payments (ActiveMerchant::Billing::PinGateway). When it makes a capture request to Pin Payments, it does not include an amount parameter in the request. It was programmed this way because the Pin Payments API would simply ignore the amount parameter, just as it would any other unrecognised parameter (because Pin Payments does not do partial captures; [a capture is always of the full authorised amount](https://pin.net.au/docs/api/charges#put-charges)).

We recently modified the Pin Payments API so that users can include an amount parameter in capture requests. It works like a programming assertion: If it is included, the server will check that the amount parameter matches the originally authorised amount. If the amounts match, the full capture will be attempted; if the amounts do not match, no capture will be attempted and the Pin Payments API will return an error response to the user.

The changes in this pull request make Active Merchant take advantage of this new feature. We think this will be helpful for Active Merchant users: if an Active Merchant user attempts a partial capture and gets an erroneous response, he is less likely to be misled into thinking that Pin Payments performed a partial capture.