### PR TITLE
Use options metadata in create_post for Stripe

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -237,7 +237,7 @@ module ActiveMerchant #:nodoc:
         post[:description] = options[:description]
         post[:statement_description] = options[:statement_description]
 
-        post[:metadata] = {}
+        post[:metadata] = options[:metadata] || {}
         post[:metadata][:email] = options[:email] if options[:email]
         post[:metadata][:order_id] = options[:order_id] if options[:order_id]
         post.delete(:metadata) if post[:metadata].empty?

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -439,6 +439,17 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_client_data_submitted_with_metadata_in_options
+    stub_comms(@gateway, :ssl_request) do
+      updated_options = @options.merge({:metadata => {:option1 => 'optional', :option2 => 'not required'}, :order_id => "42", :email => "foo@wonderfullyfakedomain.com"})
+      @gateway.purchase(@amount,@credit_card,updated_options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/metadata\[option1\]=optional/, data)
+      assert_match(/metadata\[option2\]=not\+required/, data)
+      assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
+      assert_match(/metadata\[order_id\]=42/, data)
+    end.respond_with(successful_purchase_response)
+  end
 
   def test_add_address
     post = {:card => {}}

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -441,11 +441,11 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_metadata_in_options
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({:metadata => {:option1 => 'optional', :option2 => 'not required'}, :order_id => "42", :email => "foo@wonderfullyfakedomain.com"})
+      updated_options = @options.merge({:metadata => {:this_is_a_random_key_name => 'with a random value', :i_made_up_this_key_too => 'canyoutell'}, :order_id => "42", :email => "foo@wonderfullyfakedomain.com"})
       @gateway.purchase(@amount,@credit_card,updated_options)
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/metadata\[option1\]=optional/, data)
-      assert_match(/metadata\[option2\]=not\+required/, data)
+      assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
+      assert_match(/metadata\[i_made_up_this_key_too\]=canyoutell/, data)
       assert_match(/metadata\[email\]=foo\%40wonderfullyfakedomain\.com/, data)
       assert_match(/metadata\[order_id\]=42/, data)
     end.respond_with(successful_purchase_response)


### PR DESCRIPTION
Stripe has asked for specific, currently non-standard, metadata to be included on purchase posts.

Allow said metadata to be passed in via an options field.

@j-mutter 