### PR TITLE
Ignore files generated by rdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile*.lock
 .rbx/
 *.gem
 .rvmrc
+/doc/


### PR DESCRIPTION
Add /doc/ to .gitignore file so that using rdoc to generate docs doesn't
cause git to list untracked files.