### PR TITLE
[Braintree] Add errored avs codes

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -335,7 +335,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def avs_code_from(transaction)
-        avs_mapping["street: #{transaction.avs_street_address_response_code}, zip: #{transaction.avs_postal_code_response_code}"]
+        transaction.avs_error_response_code ||
+          avs_mapping["street: #{transaction.avs_street_address_response_code}, zip: #{transaction.avs_postal_code_response_code}"]
       end
 
       def avs_mapping

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -217,6 +217,9 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_avs("", "20000", "C")
     assert_avs("", "20001", "I")
     assert_avs("", "", "I")
+
+    assert_avs("1 Elm", "30000", "E")
+    assert_avs("1 Elm", "30001", "S")
   end
 
   def test_cvv_match


### PR DESCRIPTION
## AVS Error Codes
Braintree has some AVS codes corresponding to [errors](https://developers.braintreepayments.com/ios+ruby/reference/general/processor-responses/avs-cvv-responses); these are E (AVS system error) and S(Issuing bank does not support AVS). Since these match to what's available in `avs_result` we can just return these if present. This should be returned before any other mappings, since `avs_street_address_response_code` and `avs_postal_code_response_code` according to [Braintree docs](https://developers.braintreepayments.com/ios+ruby/reference/response/transaction#avs_error_response_code).

@girasquid @j-mutter 