### PR TITLE
Stripe: Add support for idempotency keys

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -359,6 +359,7 @@ module ActiveMerchant #:nodoc:
       def headers(options = {})
         key     = options[:key] || @api_key
         version = options[:version] || @version
+        idempotency_key = options[:idempotency_key]
 
         headers = {
           "Authorization" => "Basic " + Base64.encode64(key.to_s + ":").strip,
@@ -367,6 +368,7 @@ module ActiveMerchant #:nodoc:
           "X-Stripe-Client-User-Metadata" => {:ip => options[:ip]}.to_json
         }
         headers.merge!("Stripe-Version" => version) if version
+        headers.merge!("Idempotency-Key" => idempotency_key) if idempotency_key
         headers
       end
 

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -488,6 +488,15 @@ class StripeTest < Test::Unit::TestCase
     @gateway.purchase(@amount, @credit_card, @options.merge(:version => '2013-10-29'))
   end
 
+  def test_optional_idempotency_key_header
+    @gateway.expects(:ssl_request).once.with {|method, url, post, headers|
+      headers && headers['Idempotency-Key'] == 'test123'
+    }.returns(successful_purchase_response)
+
+    @gateway.purchase(@amount, @credit_card, @options.merge(:idempotency_key => 'test123'))
+  end
+
+
   def test_initialize_gateway_with_version
     @gateway = StripeGateway.new(:login => 'login', :version => '2013-12-03')
     @gateway.expects(:ssl_request).once.with {|method, url, post, headers|


### PR DESCRIPTION
Stripe [has the ability to use an idempotency key][docs] to ensure that
a request is idempotent. This is very useful for things like retrying
a charge when Stripe returns an intermittent failure, as the request
will only be processed _once_ on Stripe's end even if the first time the
request was attempted it was actually processed.

[docs]: https://stripe.com/docs/api#idempotent_requests