### PR TITLE
Only define constant once

### DIFF
--- a/lib/active_merchant/country.rb
+++ b/lib/active_merchant/country.rb
@@ -312,7 +312,7 @@ module ActiveMerchant #:nodoc:
       { alpha2: 'ZM', name: 'Zambia', alpha3: 'ZMB', numeric: '894' },
       { alpha2: 'ZW', name: 'Zimbabwe', alpha3: 'ZWE', numeric: '716' },
       { alpha2: 'AX', name: 'Åland Islands', alpha3: 'ALA', numeric: '248' }
-    ]
+    ] unless defined?(Countries)
 
     def self.find(name)
       raise InvalidCountryCodeError, "Cannot lookup country for an empty name" if name.blank?


### PR DESCRIPTION
Gets rid of warnings about previous definitions was here.

> /Users/mhenrixon/.rvm/gems/ruby-2.2.2/gems/activemerchant-1.45.0/lib/active_merchant/country.rb:67: warning: previous definition of COUNTRIES was here