### PR TITLE
Add Omise Payment Gateway Support [TH]

### DIFF
--- a/lib/active_merchant/billing/gateways/omise.rb
+++ b/lib/active_merchant/billing/gateways/omise.rb
@@ -1,0 +1,319 @@
+require 'active_merchant/billing/rails'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class OmiseGateway < Gateway
+      API_VERSION = '1.0'
+      API_URL     = 'https://api.omise.co/'
+      VAULT_URL   = 'https://vault.omise.co/'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        'invalid_security_code' => STANDARD_ERROR_CODE[:invalid_cvc],
+        'failed_capture'        => STANDARD_ERROR_CODE[:card_declined]
+      }
+
+      self.live_url = self.test_url = API_URL
+
+      # Currency supported by Omise
+      # * Thai Baht with Satang, ie. 9000 => 90 THB
+      self.default_currency = 'THB'
+      self.money_format     = :cents
+
+      #Country supported by Omise
+      # * Thailand
+      self.supported_countries = %w( TH )
+
+      # Credit cards supported by Omise
+      # * VISA
+      # * MasterCard
+      self.supported_cardtypes = [:visa, :master]
+
+      # Omise main page
+      self.homepage_url = 'https://www.omise.co/'
+      self.display_name = 'Omise'
+
+      # Creates a new OmiseGateway.
+      #
+      # Omise requires public_key for token creation.
+      # And it requires secret_key for other transactions.
+      # These keys can be found in https://dashboard.omise.co/test/api-keys
+      #
+      # ==== Options
+      #
+      # * <tt>:public_key</tt> -- Omise's public key (REQUIRED).
+      # * <tt>:secret_key</tt> -- Omise's secret key (REQUIRED).
+
+      def initialize(options={})
+        requires!(options, :public_key, :secret_key)
+        @public_key = options[:public_key]
+        @secret_key = options[:secret_key]
+        super
+      end
+
+      # Perform a purchase (with auto capture)
+      #
+      # ==== Parameters
+      #
+      # * <tt>money</tt>          -- The purchasing amount in Thai Baht Satang
+      # * <tt>payment_method</tt> -- The CreditCard object
+      # * <tt>options</tt>        -- An optional parameters, such as token from Omise.js
+      #
+      # ==== Options
+      # * <tt>token_id</tt> -- token id, use Omise.js library to retrieve a token id
+      # if this is passed as an option, it will ignore tokenizing via Omisevaultgateway object
+      #
+      # === Example
+      #  To create a charge on a card
+      #
+      #   purchase(money, Creditcard_object)
+      #
+      #  To create a charge on a token
+      #
+      #   purchase(money, nil, { :token_id => token_id, ... })
+      #
+      #  To create a charge on a customer
+      #
+      #   purchase(money, nil, { :customer_id => customer_id })
+
+      def purchase(money, payment_method, options={})
+        create_charge(money, payment_method, options)
+      end
+
+      # Authorize a charge.
+      #
+      # ==== Parameters
+      #
+      # * <tt>money</tt>          -- The purchasing amount in Thai Baht Satang
+      # * <tt>payment_method</tt> -- The CreditCard object
+      # * <tt>options</tt>        -- An optional parameters, such as token or capture
+
+      def authorize(money, payment_method, options={})
+        options[:capture] = 'false'
+        create_charge(money, payment_method, options)
+      end
+
+      # Capture an authorized charge.
+      #
+      # ==== Parameters
+      #
+      # * <tt>money</tt>     -- An amount in Thai Baht Satang
+      # * <tt>charge_id</tt> -- The CreditCard object
+      # * <tt>options</tt>   -- An optional parameters, such as token or capture
+
+      def capture(money, charge_id, options={})
+        post = {}
+        add_amount(post, money, options)
+        commit(:post, "charges/#{CGI.escape(charge_id)}/capture", post, options)
+      end
+
+      # Refund a charge.
+      #
+      # ==== Parameters
+      #
+      # * <tt>money</tt>     -- An amount of money to charge in Satang.
+      # * <tt>charge_id</tt> -- The CreditCard object
+      # * <tt>options</tt>   -- An optional parameters, such as token or capture
+
+      def refund(money, charge_id, options={})
+        options[:amount] = money if money
+        commit(:post, "charges/#{CGI.escape(charge_id)}/refunds", options)
+      end
+
+      # Store a card details as customer
+      #
+      # ==== Parameters
+      #
+      # * <tt>payment_method</tt> -- The CreditCard.
+      # * <tt>options</tt>        -- Optional Customer information:
+      #     'email'       (A customer email)
+      #     'description' (A customer description)
+
+      def store(payment_method, options={})
+        post, card_params = {}, {}
+        add_customer_data(post, options)
+        add_token(card_params, payment_method, options)
+        commit(:post, 'customers', post.merge(card_params), options)
+      end
+
+      # Delete a customer and all associated credit cards.
+      #
+      # ==== Parameters
+      #
+      # * <tt>customer_id</tt> -- The Customer identifier (REQUIRED).
+
+      def unstore(customer_id, options={})
+        commit(:delete, "customers/#{CGI.escape(customer_id)}")
+      end
+
+      # Enable scrubbling sensitive information
+      def supports_scrubbing?
+        true
+      end
+
+      # Scrub sensitive information out of HTTP transcripts
+      #
+      # ==== Parameters
+      #
+      # * <tt>transcript</tt> -- The HTTP transcripts
+
+      def scrub(transcript)
+        transcript.
+          gsub(/(Authorization: Basic )\w+/i, '\1[FILTERED]').
+          gsub(/(\\"number\\":)\\"\d+\\"/, '\1[FILTERED]').
+          gsub(/(\\"security_code\\":)\\"\d+\\"/,'\1[FILTERED]')
+      end
+
+      private
+
+      def create_charge(money, payment_method, options)
+        post = {}
+        add_token(post, payment_method, options)
+        add_amount(post, money, options)
+        add_customer(post, options)
+        post[:capture] = options[:capture] if options[:capture]
+        commit(:post, 'charges', post, options)
+      end
+
+      def headers(options={})
+        key = options[:key] || @secret_key
+        {
+          'Content-Type'    => 'application/json;utf-8',
+          'User-Agent'      => "Omise/v#{API_VERSION} ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+          'Authorization'   => 'Basic ' + Base64.encode64(key.to_s + ':').strip,
+          'Accept-Encoding' => 'utf-8'
+        }
+      end
+
+      def url_for(endpoint)
+        (endpoint == 'tokens' ? VAULT_URL : API_URL) + endpoint
+      end
+
+      def post_data(parameters)
+        parameters.present? ? parameters.to_json : nil
+      end
+
+      def https_request(method, endpoint, parameters=nil, options={})
+        raw_response = response = nil
+        begin
+          raw_response = ssl_request(method, url_for(endpoint), post_data(parameters), headers(options))
+          response = parse(raw_response)
+        rescue ResponseError => e
+          raw_response = e.response.body
+          response = parse(raw_response)
+        rescue JSON::ParserError
+          response = json_error(raw_response)
+        end
+        response
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def json_error(raw_response)
+        msg  = "Invalid response received from Omise API. Please contact support@omise.co if you continue to receive this message."
+        msg += "The raw response returned by the API was #{raw_response.inspect})"
+        { message: msg }
+      end
+
+      def commit(method, endpoint, params=nil, options={})
+        response = https_request(method, endpoint, params, options)
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
+          {
+            authorization: authorization_from(response),
+            test: test?,
+            error_code: successful?(response) ? nil : standard_error_code_mapping(response)
+          }
+        )
+      end
+
+      def standard_error_code_mapping(response)
+        STANDARD_ERROR_CODE_MAPPING[error_code_from(response)] || message_to_standard_error_code_from(response)
+      end
+
+      def error_code_from(response)
+        error?(response) ? response['code'] : response['failure_code']
+      end
+
+      def message_to_standard_error_code_from(response)
+        message = response['message'] if response['code'] == 'invalid_card'
+        case message
+          when /brand not supported/
+            STANDARD_ERROR_CODE[:invalid_number]
+          when /number is invalid/
+            STANDARD_ERROR_CODE[:incorrect_number]
+          when /expiration date cannot be in the past/
+            STANDARD_ERROR_CODE[:expired_card]
+          when /expiration \w+ is invalid/
+            STANDARD_ERROR_CODE[:invalid_expiry_date]
+          else
+            STANDARD_ERROR_CODE[:processing_error]
+        end
+      end
+
+      def message_from(response)
+        if successful?(response)
+          'Success'
+        else
+          (response['message'] ? response['message'] : response['failure_message'])
+        end
+      end
+
+      def authorization_from(response)
+        response['id'] if successful?(response)
+      end
+
+      def successful?(response)
+        !error?(response) && response['failure_code'].nil?
+      end
+
+      def error?(response)
+        response.key?('object') && (response['object'] == 'error')
+      end
+
+      def get_token(post, credit_card)
+        add_creditcard(post, credit_card) if credit_card
+        commit(:post, 'tokens', post, { key: @public_key })
+      end
+
+      def add_token(post, credit_card, options={})
+        if options[:token_id].present?
+          post[:card] = options[:token_id]
+        else
+          response = get_token(post, credit_card)
+          response.authorization ? (post[:card] = response.authorization) : response
+        end
+      end
+
+      def add_creditcard(post, payment_method)
+        card = {
+          number:           payment_method.number,
+          name:             payment_method.name,
+          security_code:    payment_method.verification_value,
+          expiration_month: payment_method.month,
+          expiration_year:  payment_method.year
+        }
+        post[:card] = card
+      end
+
+      def add_customer(post, options={})
+        post[:customer] = options[:customer_id] if options[:customer_id]
+      end
+
+      def add_customer_data(post, options={})
+        post[:description] = options[:description] if options[:description]
+        post[:email]       = options[:email] if options[:email]
+      end
+
+      def add_amount(post, money, options)
+        post[:amount]      = amount(money)
+        post[:currency]    = (options[:currency] || currency(money))
+        post[:description] = options[:description] if options.key?(:description)
+      end
+
+    end
+  end
+end

--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -68,6 +68,9 @@ module ActiveMerchant
             when :put
               debug body
               http.put(endpoint.request_uri, body, headers)
+            when :patch
+              debug body
+              http.patch(endpoint.request_uri, body, headers)
             when :delete
               # It's kind of ambiguous whether the RFC allows bodies
               # for DELETE requests. But Net::HTTP's delete method

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -438,6 +438,11 @@ ogone:
   password: PASSWORD
   signature: SIGNATURE
 
+# Get credentials or api keys from https://dashboard.omise.co
+omise:
+  public_key: pkey_test_4zt0fss8gs0z6b4zlsq
+  secret_key: skey_test_4zt0fss8eklsj88dx9l
+
 # Working credentials, no need to replace
 openpay:
   key: 'sk_e568c42a6c384b7ab02cd47d2e407cab'

--- a/test/remote/gateways/remote_omise_test.rb
+++ b/test/remote/gateways/remote_omise_test.rb
@@ -1,0 +1,102 @@
+require 'test_helper'
+
+class RemoteOmiseTest < Test::Unit::TestCase
+  def setup
+    @gateway = OmiseGateway.new(fixtures(:omise))
+    @amount  = 8888
+    @credit_card   = credit_card('4242424242424242')
+    @declined_card = credit_card('4255555555555555')
+    @invalid_cvc   = credit_card('4024007148673576', {verification_value: ''})
+    @options = {
+      description: 'Active Merchant',
+      email: 'active.merchant@testing.test'
+    }
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:public_key], transcript)
+  end
+
+  def test_missing_secret_key
+    assert_raise ArgumentError do
+      OmiseGateway.new()
+    end
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card)
+    assert_success response
+    assert_equal 'Success', response.message
+    assert_equal response.params['amount'], @amount
+    assert response.params['captured'], 'captured should be true'
+    assert response.params['authorized'], 'authorized should be true'
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @invalid_cvc)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:invalid_cvc], response.error_code
+  end
+
+  def test_successful_purchase_after_store
+    response = @gateway.store(@credit_card)
+    response = @gateway.purchase(@amount, nil, { customer_id: response.authorization })
+    assert_success response
+    assert_equal response.params['amount'], @amount
+  end
+
+  def test_failed_purchase_with_token
+    response = @gateway.purchase(@amount, nil, {token_id: 'tokn_invalid_12345'})
+    assert_failure response
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert response.params['id'].match(/cust_test_[1-9a-z]+/)
+  end
+
+  def test_failed_store
+    response = @gateway.store(@declined_card, @options)
+    assert_failure response
+  end
+
+  def test_successful_unstore
+    response = @gateway.store(@credit_card, @options)
+    customer = @gateway.unstore(response.params['id'])
+    assert customer.params['deleted']
+  end
+
+  def test_authorize
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+    assert_equal authorize.params['amount'], @amount
+    assert !authorize.params['captured'], 'captured should be false'
+    assert authorize.params['authorized'], 'authorized should be true'
+  end
+
+  def test_authorize_and_capture
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    capture   = @gateway.capture(@amount, authorize.authorization, @options)
+    assert_success capture
+    assert capture.params['captured'], 'captured should be true'
+    assert capture.params['authorized'], 'authorized should be true'
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    assert_equal purchase.params['amount'], @amount
+    response = @gateway.refund(@amount-1000, purchase.authorization)
+    assert_success response
+    assert_equal @amount-1000, response.params['amount']
+  end
+
+end

--- a/test/unit/gateways/omise_test.rb
+++ b/test/unit/gateways/omise_test.rb
@@ -1,0 +1,805 @@
+require 'test_helper'
+
+class OmiseTest < Test::Unit::TestCase
+  def setup
+    @gateway = OmiseGateway.new(
+      public_key: 'pkey_test_abc',
+      secret_key: 'skey_test_123',
+    )
+
+    @credit_card = credit_card
+    @amount = 3333
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+
+    @card_token = {
+      object: 'token',
+      id: 'tokn_test_4zgf1crg50rdb68xlk5'
+    };
+  end
+
+  def test_supported_countries
+    assert_equal @gateway.supported_countries, %w( TH )
+  end
+
+  def test_supports_scrubbing
+    assert @gateway.supports_scrubbing?
+  end
+
+  def test_scrub
+    assert_equal post_scrubbed, @gateway.scrub(pre_scrubbed)
+  end
+
+  def test_gateway_url
+     assert_equal 'https://api.omise.co/', OmiseGateway::API_URL
+     assert_equal 'https://vault.omise.co/', OmiseGateway::VAULT_URL
+  end
+
+  def test_request_headers
+    headers = @gateway.send(:headers, { key: 'pkey_test_555' })
+    assert_equal 'Basic cGtleV90ZXN0XzU1NTo=', headers['Authorization']
+    assert_equal 'application/json;utf-8', headers['Content-Type']
+  end
+
+  def test_post_data
+    post_data = @gateway.send(:post_data, { card: {number: '4242424242424242'} })
+    assert_equal "{\"card\":{\"number\":\"4242424242424242\"}}", post_data
+  end
+
+  def test_parse_response
+    response = @gateway.send(:parse, successful_purchase_response)
+    assert(response.key?('object'), "expect json response has object key")
+  end
+
+  def test_successful_response
+    response = @gateway.send(:parse, successful_purchase_response)
+    success  = @gateway.send(:successful?, response)
+    assert(success, "expect success to be true")
+  end
+
+  def test_error_response
+    response = @gateway.send(:parse, error_response)
+    success  = @gateway.send(:successful?, response)
+    assert(!success, "expect success to be false")
+  end
+
+  def test_error_code_from
+    response = @gateway.send(:parse, invalid_security_code_response)
+    error_code  = @gateway.send(:error_code_from, response)
+    assert_equal 'invalid_security_code', error_code
+  end
+
+  def test_standard_error_code_mapping
+    invalid_expiration_date = @gateway.send(:parse, invalid_expiration_date_response)
+    invalid_expiration_date_code = @gateway.send(:standard_error_code_mapping, invalid_expiration_date)
+    assert_equal 'invalid_expiry_date', invalid_expiration_date_code
+  end
+
+  def test_invalid_cvc
+    invalid_security_code = @gateway.send(:parse, invalid_security_code_response)
+    invalid_cvc_code = @gateway.send(:standard_error_code_mapping, invalid_security_code)
+    assert_equal 'invalid_cvc', invalid_cvc_code
+  end
+
+  def test_card_declined
+    card_declined =  @gateway.send(:parse, failed_capture_response)
+    card_declined_code = @gateway.send(:standard_error_code_mapping, card_declined)
+    assert_equal 'card_declined', card_declined_code
+  end
+
+  def test_invalid_number
+    invalid_number = @gateway.send(:parse, incorrect_number_response)
+    invalid_number_code = @gateway.send(:standard_error_code_mapping, invalid_number)
+    assert_equal 'invalid_number', invalid_number_code
+  end
+
+  def test_invalid_expiry_date
+    expiration_year = @gateway.send(:parse, invalid_expiration_year_response)
+    invalid_expiry_date_code = @gateway.send(:standard_error_code_mapping, expiration_year)
+    assert_equal 'invalid_expiry_date', invalid_expiry_date_code
+
+    expiration_month = @gateway.send(:parse, invalid_expiration_month_response)
+    invalid_expiry_date_code = @gateway.send(:standard_error_code_mapping, expiration_month)
+    assert_equal 'invalid_expiry_date', invalid_expiry_date_code
+  end
+
+  def test_successful_api_request
+    @gateway.expects(:ssl_request).returns(successful_list_charges_response)
+    response = @gateway.send(:https_request, :get, 'charges')
+    assert(!response.empty?)
+  end
+
+  def test_message_from_response
+    response = @gateway.send(:parse, error_response)
+    assert_equal 'failed fraud check', @gateway.send(:message_from, response)
+  end
+
+  def test_authorization_from_response
+    response = @gateway.send(:parse, successful_purchase_response)
+    assert_equal 'chrg_test_4zgf1d2wbstl173k99v', @gateway.send(:authorization_from, response)
+  end
+
+  def test_add_creditcard
+    result = {}
+    @gateway.send(:add_creditcard, result, @credit_card)
+    assert_equal @credit_card.number, result[:card][:number]
+    assert_equal @credit_card.verification_value, result[:card][:security_code]
+    assert_equal 'Longbob Longsen', result[:card][:name]
+  end
+
+  def test_add_customer_without_card
+    result = {}
+    customer_id = 'cust_test_4zjzcgm8kpdt4xdhdw2'
+    @gateway.send(:add_customer, result, {customer_id: customer_id})
+    assert_equal 'cust_test_4zjzcgm8kpdt4xdhdw2', result[:customer]
+  end
+
+  def test_add_customer_with_card_id
+    result = {}
+    customer_id   = 'cust_test_4zjzcgm8kpdt4xdhdw2'
+    result[:card] = 'card_test_4zguktjcxanu3dw171a'
+    @gateway.send(:add_customer, result, {customer_id: customer_id})
+    assert_equal customer_id, result[:customer]
+  end
+
+  def test_add_amount
+    result = {}
+    desc = 'Charge for order 3947'
+    @gateway.send(:add_amount, result, @amount, {description: desc})
+    assert_equal desc, result[:description]
+  end
+
+  def test_commit_transaction
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+    response = @gateway.send(:commit, :post, 'charges', {})
+    assert_equal 'chrg_test_4zgf1d2wbstl173k99v', response.authorization
+  end
+
+  def test_successful_token_exchange
+    @gateway.expects(:ssl_request).returns(successful_token_exchange)
+    token = @gateway.send(:get_token, {}, @credit_card)
+    assert_equal 'tokn_test_4zgf1crg50rdb68xlk5', token.params['id']
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_request).twice.returns(successful_token_exchange, successful_purchase_response)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'chrg_test_4zgf1d2wbstl173k99v', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_request).twice.returns(successful_token_exchange, successful_authorize_response)
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'chrg_test_4zmqak4ccnfut5maxp7', response.authorization
+    assert response.test?
+    assert response.params['authorized']
+  end
+
+  def test_successful_store
+    @gateway.expects(:ssl_request).twice.returns(successful_token_exchange, successful_store_response)
+    response = @gateway.store(@credit_card, @options)
+    assert_equal 'cust_test_4zkp720zggu4rubgsqb', response.authorization
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_request).returns(successful_capture_response)
+    response = @gateway.send(:capture, @amount, 'chrg_test_4z5goqdwpjebu1gsmqq')
+    assert_equal 'chrg_test_4z5goqdwpjebu1gsmqq', response.params['id']
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_request).returns(failed_capture_response)
+    response = @gateway.send(:capture, @amount, 'chrg_test_4z5goqdwpjebu1gsmqq')
+    assert_equal 'Charge is not authorized', response.message
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_request).returns(successful_refund_response)
+    response = @gateway.send(:refund, @amount, 'chrg_test_4z5goqdwpjebu1gsmqq')
+    assert_equal 'rfnd_test_4zmbpt1zwdsqtmtffw8', response.params['id']
+  end
+
+  def test_successful_partial_refund
+    @gateway.expects(:ssl_request).returns(successful_partial_refund_response)
+    response = @gateway.send(:refund, 1000, 'chrg_test_4z5goqdwpjebu1gsmqq')
+    assert_equal 1000, response.params['amount']
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_request).returns(failed_refund_response)
+    response = @gateway.send(:refund, 9999999, 'chrg_test_4z5goqdwpjebu1gsmqq')
+    assert_equal "charge can't be refunded", response.message
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-'PRE_SCRUBED'
+      opening connection to vault.omise.co:443...
+      opened
+      starting SSL for vault.omise.co:443...
+      SSL established
+      <- "POST /tokens HTTP/1.1\r\nContent-Type: application/json;utf-8\r\nUser-Agent: Omise/v1.0 ActiveMerchantBindings/1.48.0\r\nAuthorization: Basic cGtleV90ZXN0XzR6dDBmc3M4Z3MwejZiNHpsc3E6\r\nAccept-Encoding: utf-8\r\nAccept: */*\r\nConnection: close\r\nHost: vault.omise.co\r\nContent-Length: 129\r\n\r\n"
+      <- "{\"card\":{\"number\":\"4242424242424242\",\"name\":\"Longbob Longsen\",\"security_code\":\"123\",\"expiration_month\":9,\"expiration_year\":2016}}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Cache-Control: no-cache, no-store\r\n"
+      -> "Content-Type: application/json; charset=utf-8\r\n"
+      -> "Date: Tue, 28 Apr 2015 11:28:04 GMT\r\n"
+      -> "Omise-Version: 2015-04-24\r\n"
+      -> "Server: nginx\r\n"
+      -> "Status: 200 OK\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubdomains\r\n"
+      -> "Vary: Accept-Encoding\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-Request-Id: 6fe70604-c96c-425a-bdc1-2c50049be41b\r\n"
+      -> "X-Runtime: 0.083059\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "Content-Length: 680\r\n"
+      -> "Connection: Close\r\n"
+      -> "\r\n"
+      reading 680 bytes...
+      -> "{\n  \"object\": \"token\",\n  \"id\": \"tokn_test_4zulil6gzuconeb4mrm\",\n  \"livemode\": false,\n  \"location\": \"https://vault.omise.co/tokens/tokn_test_4zulil6gzuconeb4mrm\",\n  \"used\": false,\n  \"card\": {\n    \"object\": \"card\",\n    \"id\": \"card_test_4zulil6fy04h678xb52\",\n    \"livemode\": false,\n    \"country\": \"us\",\n    \"city\": null,\n    \"postal_code\": null,\n    \"financing\": \"\",\n    \"last_digits\": \"4242\",\n    \"brand\": \"Visa\",\n    \"expiration_month\": 9,\n    \"expiration_year\": 2016,\n    \"fingerprint\": \"MYfx1beqiXkgHgJMoH+LzpyuspoeQZoQDmsI1GDSl/A=\",\n    \"name\": \"Longbob Longsen\",\n    \"security_code_check\": true,\n    \"created\": \"2015-04-28T11:30:28Z\"\n  },\n  \"created\": \"2015-04-28T11:30:28Z\"\n}\n"
+      read 680 bytes
+      Conn close
+    PRE_SCRUBED
+  end
+
+  def post_scrubbed
+    <<-'POST_SCRUBBED'
+      opening connection to vault.omise.co:443...
+      opened
+      starting SSL for vault.omise.co:443...
+      SSL established
+      <- "POST /tokens HTTP/1.1\r\nContent-Type: application/json;utf-8\r\nUser-Agent: Omise/v1.0 ActiveMerchantBindings/1.48.0\r\nAuthorization: Basic [FILTERED]\r\nAccept-Encoding: utf-8\r\nAccept: */*\r\nConnection: close\r\nHost: vault.omise.co\r\nContent-Length: 129\r\n\r\n"
+      <- "{\"card\":{\"number\":[FILTERED],\"name\":\"Longbob Longsen\",\"security_code\":[FILTERED],\"expiration_month\":9,\"expiration_year\":2016}}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Cache-Control: no-cache, no-store\r\n"
+      -> "Content-Type: application/json; charset=utf-8\r\n"
+      -> "Date: Tue, 28 Apr 2015 11:28:04 GMT\r\n"
+      -> "Omise-Version: 2015-04-24\r\n"
+      -> "Server: nginx\r\n"
+      -> "Status: 200 OK\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubdomains\r\n"
+      -> "Vary: Accept-Encoding\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-Request-Id: 6fe70604-c96c-425a-bdc1-2c50049be41b\r\n"
+      -> "X-Runtime: 0.083059\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "Content-Length: 680\r\n"
+      -> "Connection: Close\r\n"
+      -> "\r\n"
+      reading 680 bytes...
+      -> "{\n  \"object\": \"token\",\n  \"id\": \"tokn_test_4zulil6gzuconeb4mrm\",\n  \"livemode\": false,\n  \"location\": \"https://vault.omise.co/tokens/tokn_test_4zulil6gzuconeb4mrm\",\n  \"used\": false,\n  \"card\": {\n    \"object\": \"card\",\n    \"id\": \"card_test_4zulil6fy04h678xb52\",\n    \"livemode\": false,\n    \"country\": \"us\",\n    \"city\": null,\n    \"postal_code\": null,\n    \"financing\": \"\",\n    \"last_digits\": \"4242\",\n    \"brand\": \"Visa\",\n    \"expiration_month\": 9,\n    \"expiration_year\": 2016,\n    \"fingerprint\": \"MYfx1beqiXkgHgJMoH+LzpyuspoeQZoQDmsI1GDSl/A=\",\n    \"name\": \"Longbob Longsen\",\n    \"security_code_check\": true,\n    \"created\": \"2015-04-28T11:30:28Z\"\n  },\n  \"created\": \"2015-04-28T11:30:28Z\"\n}\n"
+      read 680 bytes
+      Conn close
+    POST_SCRUBBED
+  end
+
+  def error_response
+    <<-RESPONSE
+    {
+      "object": "error",
+      "location": "https://docs.omise.co/api/errors#failed-fraud-check",
+      "code": "failed_fraud_check",
+      "message": "failed fraud check"
+    }
+    RESPONSE
+  end
+
+  def successful_token_exchange
+    <<-RESPONSE
+    {
+      "object": "token",
+      "id": "tokn_test_4zgf1crg50rdb68xlk5",
+      "livemode": false,
+      "location": "https://vault.omise.co/tokens/tokn_test_4zgf1crg50rdb68xlk5",
+      "used": false,
+      "card": {
+        "object": "card",
+        "id": "card_test_4zgf1crf975xnz6coa7",
+        "livemode": false,
+        "country": "us",
+        "city": "Bangkok",
+        "postal_code": "10320",
+        "financing": "",
+        "last_digits": "4242",
+        "brand": "Visa",
+        "expiration_month": 10,
+        "expiration_year": 2018,
+        "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
+        "name": "Somchai Prasert",
+        "security_code_check": true,
+        "created": "2015-03-23T05:25:14Z"
+      },
+      "created": "2015-03-23T05:25:14Z"
+    }
+    RESPONSE
+  end
+
+  def successful_list_charges_response
+    <<-RESPONSE
+    {
+      "object": "list",
+      "from": "1970-01-01T00:00:00+00:00",
+      "to": "2015-04-01T03:34:11+00:00",
+      "offset": 0,
+      "limit": 20,
+      "total": 1,
+      "data": [
+        {
+          "object": "charge",
+          "id": "chrg_test_4zgukttzllzumc25qvd",
+          "livemode": false,
+          "location": "/charges/chrg_test_4zgukttzllzumc25qvd",
+          "amount": 99,
+          "currency": "thb",
+          "description": "Charge for order 3947",
+          "capture": true,
+          "authorized": true,
+          "captured": true,
+          "transaction": "trxn_test_4zguktuecyuo77xgq38",
+          "refunded": 0,
+          "refunds": {
+            "object": "list",
+            "from": "1970-01-01T00:00:00+00:00",
+            "to": "2015-04-01T03:34:11+00:00",
+            "offset": 0,
+            "limit": 20,
+            "total": 0,
+            "data": [
+
+            ],
+            "location": "/charges/chrg_test_4zgukttzllzumc25qvd/refunds"
+          },
+          "failure_code": null,
+          "failure_message": null,
+          "card": {
+            "object": "card",
+            "id": "card_test_4zguktjcxanu3dw171a",
+            "livemode": false,
+            "country": "us",
+            "city": "Bangkok",
+            "postal_code": "10320",
+            "financing": "",
+            "last_digits": "4242",
+            "brand": "Visa",
+            "expiration_month": 2,
+            "expiration_year": 2017,
+            "fingerprint": "djVaKigLa0g0b12XdGLV8CAdy45FRrOdVsgmv4oze5I=",
+            "name": "JOHN DOE",
+            "security_code_check": true,
+            "created": "2015-03-24T07:54:32Z"
+          },
+          "customer": null,
+          "ip": null,
+          "dispute": null,
+          "created": "2015-03-24T07:54:33Z"
+        }
+      ]
+    }
+    RESPONSE
+  end
+
+  def successful_purchase_response
+    <<-RESPONSE
+    {
+      "object": "charge",
+      "id": "chrg_test_4zgf1d2wbstl173k99v",
+      "livemode": false,
+      "location": "/charges/chrg_test_4zgf1d2wbstl173k99v",
+      "amount": 100000,
+      "currency": "thb",
+      "description": null,
+      "capture": true,
+      "authorized": true,
+      "captured": true,
+      "transaction": "trxn_test_4zgf1d3f7t9k6gk8hn8",
+      "refunded": 0,
+      "refunds": {
+        "object": "list",
+        "from": "1970-01-01T00:00:00+00:00",
+        "to": "2015-03-23T05:25:15+00:00",
+        "offset": 0,
+        "limit": 20,
+        "total": 0,
+        "data": [
+
+        ],
+        "location": "/charges/chrg_test_4zgf1d2wbstl173k99v/refunds"
+      },
+      "failure_code": null,
+      "failure_message": null,
+      "card": {
+        "object": "card",
+        "id": "card_test_4zgf1crf975xnz6coa7",
+        "livemode": false,
+        "location": "/customers/cust_test_4zgf1cv8e71bbwcww1p/cards/card_test_4zgf1crf975xnz6coa7",
+        "country": "us",
+        "city": "Bangkok",
+        "postal_code": "10320",
+        "financing": "",
+        "last_digits": "4242",
+        "brand": "Visa",
+        "expiration_month": 10,
+        "expiration_year": 2018,
+        "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
+        "name": "Somchai Prasert",
+        "security_code_check": true,
+        "created": "2015-03-23T05:25:14Z"
+      },
+      "customer": "cust_test_4zgf1cv8e71bbwcww1p",
+      "ip": null,
+      "dispute": null,
+      "created": "2015-03-23T05:25:15Z"
+    }
+    RESPONSE
+  end
+
+  def successful_store_response
+    <<-RESPONSE
+    {
+      "object": "customer",
+      "id": "cust_test_4zkp720zggu4rubgsqb",
+      "livemode": false,
+      "location": "/customers/cust_test_4zkp720zggu4rubgsqb",
+      "default_card": "card_test_4zkp6xeuzurrvacxs2j",
+      "email": "john.doe@example.com",
+      "description": "John Doe (id: 30)",
+      "created": "2015-04-03T04:10:35Z",
+      "cards": {
+        "object": "list",
+        "from": "1970-01-01T00:00:00+00:00",
+        "to": "2015-04-03T04:10:35+00:00",
+        "offset": 0,
+        "limit": 20,
+        "total": 1,
+        "data": [
+          {
+            "object": "card",
+            "id": "card_test_4zkp6xeuzurrvacxs2j",
+            "livemode": false,
+            "location": "/customers/cust_test_4zkp720zggu4rubgsqb/cards/card_test_4zkp6xeuzurrvacxs2j",
+            "country": "us",
+            "city": "Bangkok",
+            "postal_code": "10320",
+            "financing": "",
+            "last_digits": "4242",
+            "brand": "Visa",
+            "expiration_month": 4,
+            "expiration_year": 2017,
+            "fingerprint": "djVaKigLa0g0b12XdGLV8CAdy45FRrOdVsgmv4oze5I=",
+            "name": "JOHN DOE",
+            "security_code_check": false,
+            "created": "2015-04-03T04:10:13Z"
+          }
+        ],
+        "location": "/customers/cust_test_4zkp720zggu4rubgsqb/cards"
+      }
+    }
+    RESPONSE
+  end
+
+  def successful_charge_response
+    <<-RESPONSE
+    {
+      "object": "charge",
+      "id": "chrg_test_4zmqak4ccnfut5maxp7",
+      "livemode": false,
+      "location": "/charges/chrg_test_4zmqak4ccnfut5maxp7",
+      "amount": 100000,
+      "currency": "thb",
+      "description": null,
+      "capture": false,
+      "authorized": true,
+      "captured": true,
+      "transaction": "trxn_test_4zmqf6njyokta57ljs1",
+      "refunded": 0,
+      "refunds": {
+        "object": "list",
+        "from": "1970-01-01T00:00:00+00:00",
+        "to": "2015-04-08T09:11:39+00:00",
+        "offset": 0,
+        "limit": 20,
+        "total": 0,
+        "data": [
+
+        ],
+        "location": "/charges/chrg_test_4zmqak4ccnfut5maxp7/refunds"
+      },
+      "failure_code": null,
+      "failure_message": null,
+      "card": {
+        "object": "card",
+        "id": "card_test_4zmqaffhmut87bi075q",
+        "livemode": false,
+        "country": "us",
+        "city": "Bangkok",
+        "postal_code": "10320",
+        "financing": "",
+        "last_digits": "4242",
+        "brand": "Visa",
+        "expiration_month": 4,
+        "expiration_year": 2017,
+        "fingerprint": "djVaKigLa0g0b12XdGLV8CAdy45FRrOdVsgmv4oze5I=",
+        "name": "JOHN DOE",
+        "security_code_check": true,
+        "created": "2015-04-08T08:45:40Z"
+      },
+      "customer": null,
+      "ip": null,
+      "dispute": null,
+      "created": "2015-04-08T08:46:02Z"
+    }
+    RESPONSE
+  end
+
+  def successful_authorize_response
+    <<-RESPONSE
+    {
+      "object": "charge",
+      "id": "chrg_test_4zmqak4ccnfut5maxp7",
+      "livemode": false,
+      "location": "/charges/chrg_test_4zmqak4ccnfut5maxp7",
+      "amount": 100000,
+      "currency": "thb",
+      "description": null,
+      "capture": false,
+      "authorized": true,
+      "captured": false,
+      "transaction": null,
+      "refunded": 0,
+      "refunds": {
+        "object": "list",
+        "from": "1970-01-01T00:00:00+00:00",
+        "to": "2015-04-08T08:46:02+00:00",
+        "offset": 0,
+        "limit": 20,
+        "total": 0,
+        "data": [
+
+        ],
+        "location": "/charges/chrg_test_4zmqak4ccnfut5maxp7/refunds"
+      },
+      "failure_code": null,
+      "failure_message": null,
+      "card": {
+        "object": "card",
+        "id": "card_test_4zmqaffhmut87bi075q",
+        "livemode": false,
+        "country": "us",
+        "city": "Bangkok",
+        "postal_code": "10320",
+        "financing": "",
+        "last_digits": "4242",
+        "brand": "Visa",
+        "expiration_month": 4,
+        "expiration_year": 2017,
+        "fingerprint": "djVaKigLa0g0b12XdGLV8CAdy45FRrOdVsgmv4oze5I=",
+        "name": "JOHN DOE",
+        "security_code_check": true,
+        "created": "2015-04-08T08:45:40Z"
+      },
+      "customer": null,
+      "ip": null,
+      "dispute": null,
+      "created": "2015-04-08T08:46:02Z"
+      }
+    RESPONSE
+  end
+
+  def successful_capture_response
+    <<-RESPONSE
+    { "object": "charge",
+      "id": "chrg_test_4z5goqdwpjebu1gsmqq",
+      "livemode": false,
+      "location": "/charges/chrg_test_4z5goqdwpjebu1gsmqq",
+      "amount": 100000,
+      "currency": "thb",
+      "description": "Charge for order 3947",
+      "capture": false,
+      "authorized": true,
+      "captured": true,
+      "transaction": "trxn_test_4z5gp0t3mpfsu28u8jo",
+      "refunded": 0,
+      "refunds": {
+        "object": "list",
+        "from": "1970-01-01T00:00:00+00:00",
+        "to": "2015-02-23T05:16:54+00:00",
+        "offset": 0,
+        "limit": 20,
+        "total": 0,
+        "data": [
+
+        ],
+        "location": "/charges/chrg_test_4z5goqdwpjebu1gsmqq/refunds"
+      },
+      "return_uri": "http://www.example.com/orders/3947/complete",
+      "reference": "paym_4z5goqdw6rblbxztm4c",
+      "authorize_uri": "https://api.omise.co/payments/paym_4z5goqdw6rblbxztm4c/authorize",
+      "failure_code": null,
+      "failure_message": null,
+      "card": {
+        "object": "card",
+        "id": "card_test_4z5gogdycbrium283yk",
+        "livemode": false,
+        "country": "us",
+        "city": "Bangkok",
+        "postal_code": "10320",
+        "financing": "",
+        "last_digits": "4242",
+        "brand": "Visa",
+        "expiration_month": 2,
+        "expiration_year": 2017,
+        "fingerprint": "umrBpbHRuc8vstbcNEZPbnKkIycR/gvI6ivW9AshKCw=",
+        "name": "JOHN DOE",
+        "security_code_check": true,
+        "created": "2015-02-23T05:15:18Z"
+      },
+      "customer": null,
+      "ip": null,
+      "created": "2015-02-23T05:16:05Z"
+    }
+    RESPONSE
+  end
+
+  def successful_refund_response
+    <<-RESPONSE
+    { "object": "refund",
+      "id": "rfnd_test_4zmbpt1zwdsqtmtffw8",
+      "location": "/charges/chrg_test_4zmbg6gtzz7zhf6rio6/refunds/rfnd_test_4zmbpt1zwdsqtmtffw8",
+      "amount": 3333,
+      "currency": "thb",
+      "charge": "chrg_test_4zmbg6gtzz7zhf6rio6",
+      "transaction": "trxn_test_4zmbpt23zmi9acu4qzk",
+      "created": "2015-04-07T07:55:21Z"
+     }
+    RESPONSE
+  end
+
+  def successful_partial_refund_response
+    <<-RESPONSE
+    { "object": "refund",
+      "id": "rfnd_test_4zmbpt1zwdsqtmtffw8",
+      "location": "/charges/chrg_test_4zmbg6gtzz7zhf6rio6/refunds/rfnd_test_4zmbpt1zwdsqtmtffw8",
+      "amount": 1000,
+      "currency": "thb",
+      "charge": "chrg_test_4zmbg6gtzz7zhf6rio6",
+      "transaction": "trxn_test_4zmbpt23zmi9acu4qzk",
+      "created": "2015-04-07T07:55:21Z"
+     }
+    RESPONSE
+  end
+
+  def failed_refund_response
+    <<-RESPONSE
+    { "object": "error",
+      "location": "https://docs.omise.co/api/errors#failed-refund",
+      "code": "failed_refund",
+      "message": "charge can't be refunded"
+    }
+    RESPONSE
+  end
+
+  def invalid_expiration_month_response
+    <<-RESPONSE
+    {
+      "object": "error",
+      "location": "https://docs.omise.co/api/errors#invalid-card",
+      "code": "invalid_card",
+      "message": "expiration month is not between 1 and 12 and expiration date is invalid"
+    }
+    RESPONSE
+  end
+
+  def invalid_expiration_year_response
+    <<-RESPONSE
+    {
+      "object": "error",
+      "location": "https://docs.omise.co/api/errors#invalid-card",
+      "code": "invalid_card",
+      "message": "expiration year is invalid"
+    }
+    RESPONSE
+  end
+
+  def invalid_expiration_date_response
+    <<-RESPONSE
+    {
+      "object": "error",
+      "location": "https://docs.omise.co/api/errors#invalid-card",
+      "code": "invalid_card",
+      "message": "expiration month is not between 1 and 12 and expiration date is invalid"
+    }
+    RESPONSE
+  end
+
+  def incorrect_number_response
+    <<-RESPONSE
+    {
+      "object": "error",
+      "location": "https://docs.omise.co/api/errors#invalid-card",
+      "code": "invalid_card",
+      "message": "number is invalid and brand not supported (unknown)"
+    }
+    RESPONSE
+  end
+
+  def invalid_security_code_response
+    <<-RESPONSE
+    {
+      "object": "charge",
+      "id": "chrg_4zyeviyhhhs7sow8c3k",
+      "livemode": true,
+      "location": "/charges/chrg_4zyeviyhhhs7sow8c3k",
+      "amount": 111,
+      "currency": "thb",
+      "description": "activemerchant testing",
+      "capture": true,
+      "authorized": false,
+      "captured": false,
+      "transaction": null,
+      "refunded": 0,
+      "refunds": {
+        "object": "list",
+        "from": "1970-01-01T00:00:00+00:00",
+        "to": "2015-05-08T05:37:50+00:00",
+        "offset": 0,
+        "limit": 20,
+        "total": 0,
+        "data": [
+
+        ],
+        "location": "/charges/chrg_4zyeviyhhhs7sow8c3k/refunds"
+      },
+      "failure_code": "invalid_security_code",
+      "failure_message": "the security code is invalid",
+      "card": {
+        "object": "card",
+        "id": "card_4zyevhammij8qhn2z59",
+        "livemode": true,
+        "country": "th",
+        "city": "Bangkok",
+        "postal_code": "11111",
+        "financing": "",
+        "last_digits": "1111",
+        "brand": "Visa",
+        "expiration_month": 1,
+        "expiration_year": 2021,
+        "fingerprint": "7qTrZY+fWNSQ9JTizVeVV7Jph4RBg6qANX3rBMXhpuE=",
+        "name": "WARACHET SAMTALEE",
+        "security_code_check": false,
+        "created": "2015-05-08T05:37:42Z"
+      },
+      "customer": null,
+      "ip": null,
+      "dispute": null,
+      "created": "2015-05-08T05:37:50Z"
+    }
+    RESPONSE
+  end
+
+  def failed_capture_response
+    <<-RESPONSE
+    {
+      "object": "error",
+      "location": "https://docs.omise.co/api/errors#failed-capture",
+      "code": "failed_capture",
+      "message": "Charge is not authorized"
+    }
+    RESPONSE
+  end
+
+end


### PR DESCRIPTION
This pull request adds support for Omise payment gateway from Thailand. (https://www.omise.co)
We support Visa and MasterCard, and most debit cards from Thailand.
We are fully PCI-DSS 3.0 compliant. Our certificate can be found here: https://www.omise.co/blog/2015-02-18-how-secure-is-omise.html 

Our restful json API supports authorize, capture, partial or full refund, and saving the card as customer profile for later charging.
We use the PATCH method in the API to update the card token, converting it to a customer profile. We've added it on the pull request, hope that's ok. 

Discussion on this pull request are welcome!
API Reference: https://docs.omise.co 
Thanks,
Omise Team