### PR TITLE
SecurePay Australia: Update API URL

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -8,8 +8,8 @@ module ActiveMerchant #:nodoc:
 
       class_attribute :test_periodic_url, :live_periodic_url
 
-      self.test_url = 'https://www.securepay.com.au/test/payment'
-      self.live_url = 'https://www.securepay.com.au/xmlapi/payment'
+      self.test_url = 'https://api.securepay.com.au/test/payment'
+      self.live_url = 'https://api.securepay.com.au/xmlapi/payment'
 
       self.test_periodic_url = 'https://test.securepay.com.au/xmlapi/periodic'
       self.live_periodic_url = 'https://api.securepay.com.au/xmlapi/periodic'


### PR DESCRIPTION
@ivanfer @aprofeit 

Remote test results:
```
~/src/active_merchant[update-securepay-au-url*]: rt test/remote/gateways/remote_secure_pay_au_test.rb 
Loaded suite test/remote/gateways/remote_secure_pay_au_test
Started
...........E
============================================================================================================================================================================================================
Error: test_successful_purchase_with_custom_credit_card_class(RemoteSecurePayAuTest)
: ArgumentError: wrong number of arguments (1 for 0)
test/remote/gateways/remote_secure_pay_au_test.rb:43:in `initialize'
test/remote/gateways/remote_secure_pay_au_test.rb:43:in `new'
test/remote/gateways/remote_secure_pay_au_test.rb:43:in `test_successful_purchase_with_custom_credit_card_class'
     40:       :verification_value => '123',
     41:       :brand => 'visa'
     42:     }
  => 43:     credit_card = MyCreditCard.new(options)
     44:     assert response = @gateway.purchase(@amount, credit_card, @options)
     45:     assert_success response
     46:     assert_equal 'Approved', response.message
============================================================================================================================================================================================================
....F
============================================================================================================================================================================================================
Failure:
  Response expected to succeed: <#<ActiveMerchant::Billing::Response:0x007f2eddde51f8
   @authorization="*2**100",
   @avs_result=
    {"code"=>nil, "message"=>nil, "street_match"=>nil, "postal_match"=>nil},
   @cvv_result={"code"=>nil, "message"=>nil},
   @emv_authorization=nil,
   @error_code=nil,
   @fraud_review=nil,
   @message="Credit card details not available",
   @params=
    {"message_id"=>"83b0ea5cd159bca5529ca3974e5bbf",
     "message_timestamp"=>"20152804064711766000+600",
     "api_version"=>"xml-4.2",
     "request_type"=>"Payment",
     "merchant_id"=>"ABC0030",
     "status_code"=>"000",
     "status_description"=>"Normal",
     "txn_type"=>"6",
     "txn_source"=>"23",
     "amount"=>"100",
     "currency"=>"AUD",
     "purchase_order_no"=>"2",
     "approved"=>"No",
     "response_code"=>"133",
     "response_text"=>"Credit card details not available",
     "thinlink_response_code"=>"300",
     "thinlink_response_text"=>"000",
     "thinlink_event_status_code"=>"999",
     "thinlink_event_status_text"=>
      "Error - Transaction for Refund Not in Database",
     "settlement_date"=>nil,
     "txn_id"=>nil,
     "pan"=>nil,
     "expiry_date"=>nil,
     "card_type"=>"0",
     "card_description"=>nil},
   @success=false,
   @test=true>>
test_successful_void(RemoteSecurePayAuTest)
test/remote/gateways/remote_secure_pay_au_test.rb:109:in `test_successful_void'
     106: 
     107:     assert result = @gateway.void(authorization)
     108: 
  => 109:     assert_success result
     110:     assert_equal 'Approved', result.message
     111:   end
     112: 
============================================================================================================================================================================================================


Finished in 75.083312864 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
17 tests, 59 assertions, 1 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
88.2353% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.23 tests/s, 0.79 assertions/s
```

The two failures fail consistently if I change the URL back, so - at least I'm not breaking it more? Going to look into them in a follow-up PR.