### PR TITLE
Truncate card number

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -51,6 +51,8 @@ module ActiveMerchant #:nodoc:
 
       APPLE_PAY_DATA_DESCRIPTOR = "COMMON.APPLE.INAPP.PAYMENT"
 
+      CREDIT_CARD_NUMBER_MAX_LENGTH = 16
+
       def initialize(options={})
         requires!(options, :login, :password)
         super
@@ -232,7 +234,7 @@ module ActiveMerchant #:nodoc:
         else
           xml.payment do
             xml.creditCard do
-              xml.cardNumber(credit_card.number)
+              xml.cardNumber(truncate(credit_card.number, CREDIT_CARD_NUMBER_MAX_LENGTH))
               xml.expirationDate(format(credit_card.month, :two_digits) + '/' + format(credit_card.year, :four_digits))
               if credit_card.valid_card_verification_value?(credit_card.verification_value, credit_card.brand)
                 xml.cardCode(credit_card.verification_value)

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -638,6 +638,17 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end
   end
 
+  def test_card_number_truncation
+    card = credit_card(@credit_card.number + '0123456789')
+    stub_comms do
+      @gateway.purchase(@amount, card)
+    end.check_request do |endpoint, data, headers|
+      parse(data) do |doc|
+        assert_equal @credit_card.number, doc.at_xpath('//cardNumber').text
+      end
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_scrub
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end


### PR DESCRIPTION
This avoids an XSD related error. The authorize.net XSD stipulates:

```xml
<xs:element name="cardNumber">
  <xs:simpleType>
    <xs:restriction base="xs:string">
      <xs:minLength value="4"/>
      <xs:maxLength value="16"/>
    </xs:restriction>
  </xs:simpleType>
</xs:element>
```

Also, I decided to use a constant for the max card number length value. Other truncation values in this class are hardcoded/magic numbers. Normally, I'd feel strongly against magic numbers, but if a magic number would be better here for consistency, that seems reasonable to me.