### PR TITLE
Stripe: Split up the remote tests

### DIFF
--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -1,0 +1,131 @@
+require 'test_helper'
+
+class RemoteStripeApplePayTest < Test::Unit::TestCase
+  def setup
+    @gateway = StripeGateway.new(fixtures(:stripe))
+    @amount = 100
+
+    @options = {
+      :currency => "USD",
+      :description => 'ActiveMerchant Test Purchase',
+      :email => 'wow@example.com'
+    }
+    @apple_pay_payment_token = apple_pay_payment_token
+  end
+
+  def test_successful_purchase_with_apple_pay_payment_token
+    assert response = @gateway.purchase(@amount, @apple_pay_payment_token, @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  def test_authorization_and_capture_with_apple_pay_payment_token
+    assert authorization = @gateway.authorize(@amount, @apple_pay_payment_token, @options)
+    assert_success authorization
+    refute authorization.params["captured"]
+    assert_equal "ActiveMerchant Test Purchase", authorization.params["description"]
+    assert_equal "wow@example.com", authorization.params["metadata"]["email"]
+
+    assert capture = @gateway.capture(@amount, authorization.authorization)
+    assert_success capture
+  end
+
+  def test_authorization_and_void_with_apple_pay_payment_token
+    assert authorization = @gateway.authorize(@amount, @apple_pay_payment_token, @options)
+    assert_success authorization
+    refute authorization.params["captured"]
+
+    assert void = @gateway.void(authorization.authorization)
+    assert_success void
+  end
+
+  def test_successful_void_with_apple_pay_payment_token
+    assert response = @gateway.purchase(@amount, @apple_pay_payment_token, @options)
+    assert_success response
+    assert response.authorization
+    assert void = @gateway.void(response.authorization)
+    assert_success void
+  end
+
+  def test_successful_store_with_apple_pay_payment_token
+    assert response = @gateway.store(@apple_pay_payment_token, {:description => "Active Merchant Test Customer", :email => "email@example.com"})
+    assert_success response
+    assert_equal "customer", response.params["object"]
+    assert_equal "Active Merchant Test Customer", response.params["description"]
+    assert_equal "email@example.com", response.params["email"]
+    first_card = response.params["cards"]["data"].first
+    assert_equal response.params["default_card"], first_card["id"]
+    assert_equal "4242", first_card["dynamic_last4"] # when stripe is in test mode, token exchanged will return a test card with dynamic_last4 4242
+    assert_equal "0000", first_card["last4"] # last4 is 0000 when using an apple pay token
+  end
+
+  def test_successful_store_with_existing_customer_and_apple_pay_payment_token
+    assert response = @gateway.store(@credit_card, {:description => "Active Merchant Test Customer"})
+    assert_success response
+
+    assert response = @gateway.store(@apple_pay_payment_token, {:customer => response.params['id'], :description => "Active Merchant Test Customer", :email => "email@example.com"})
+    assert_success response
+    assert_equal 2, response.responses.size
+
+    card_response = response.responses[0]
+    assert_equal "card", card_response.params["object"]
+    assert_equal "4242", card_response.params["dynamic_last4"] # when stripe is in test mode, token exchanged will return a test card with dynamic_last4 4242
+    assert_equal "0000", card_response.params["last4"] # last4 is 0000 when using an apple pay token
+
+    customer_response = response.responses[1]
+    assert_equal "customer", customer_response.params["object"]
+    assert_equal "Active Merchant Test Customer", customer_response.params["description"]
+    assert_equal "email@example.com", customer_response.params["email"]
+    assert_equal 2, customer_response.params["cards"]["count"]
+  end
+
+  def test_successful_recurring_with_apple_pay_payment_token
+    assert response = @gateway.store(@apple_pay_payment_token, {:description => "Active Merchant Test Customer", :email => "email@example.com"})
+    assert_success response
+    assert recharge_options = @options.merge(:customer => response.params["id"])
+    assert response = @gateway.purchase(@amount, nil, recharge_options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+  end
+
+  def test_purchase_with_unsuccessful_apple_pay_token_exchange
+    assert response = @gateway.purchase(@amount, ApplePayPaymentToken.new('garbage'), @options)
+    assert_failure response
+  end
+
+  def test_successful_purchase_with_apple_pay_raw_cryptogram
+    credit_card = network_tokenization_credit_card('4242424242424242',
+      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      verification_value: nil
+    )
+    assert response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  def test_successful_auth_with_apple_pay_raw_cryptogram
+    credit_card = network_tokenization_credit_card('4242424242424242',
+      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
+      verification_value: nil
+    )
+    assert response = @gateway.authorize(@amount, credit_card, @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
+    assert_equal "wow@example.com", response.params["metadata"]["email"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+
+end
+

--- a/test/remote/gateways/remote_stripe_connect_test.rb
+++ b/test/remote/gateways/remote_stripe_connect_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class RemoteStripeConnectTest < Test::Unit::TestCase
+  def setup
+    @gateway = StripeGateway.new(fixtures(:stripe))
+
+    @amount = 100
+    @credit_card = credit_card('4242424242424242')
+    @declined_card = credit_card('4000000000000002')
+    @new_credit_card = credit_card('5105105105105100')
+
+    @options = {
+      :currency => "USD",
+      :description => 'ActiveMerchant Test Purchase',
+      :email => 'wow@example.com'
+    }
+  end
+
+  def test_application_fee_for_stripe_connect
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12 ))
+    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
+    assert response.params['fee_details'].any? do |fee|
+      (fee['type'] == 'application_fee') && (fee['amount'] == 12)
+    end
+  end
+
+  def test_successful_refund_with_application_fee
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
+    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
+    assert refund = @gateway.refund(@amount, response.authorization, :refund_application_fee => true)
+    assert_success refund
+    assert_equal 0, refund.params["fee"]
+  end
+
+  def test_refund_partial_application_fee
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
+    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
+    assert refund = @gateway.refund(@amount - 20, response.authorization, { :refund_fee_amount => 10 })
+    assert_success refund
+  end
+
+end

--- a/test/remote/gateways/remote_stripe_emv_test.rb
+++ b/test/remote/gateways/remote_stripe_emv_test.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+
+class RemoteStripeEmvTest < Test::Unit::TestCase
+  def setup
+    @gateway = StripeGateway.new(fixtures(:stripe))
+
+    @amount = 100
+    @emv_credit_cards = {
+      uk: ActiveMerchant::Billing::CreditCard.new(icc_data: '500B56495341204352454449545F201A56495341204143515549524552205445535420434152442030315F24031512315F280208405F2A0208265F300202015F34010182025C008407A0000000031010950502000080009A031408259B02E8009C01009F02060000000734499F03060000000000009F0607A00000000310109F0902008C9F100706010A03A080009F120F4352454449544F20444520564953419F1A0208269F1C0831373030303437309F1E0831373030303437309F2608EB2EC0F472BEA0A49F2701809F3303E0B8C89F34031E03009F3501229F360200C39F37040A27296F9F4104000001319F4502DAC5DFAE5711476173FFFFFF0119D15122011758989389DFAE5A08476173FFFFFF011957114761739001010119D151220117589893895A084761739001010119'),
+      us: ActiveMerchant::Billing::CreditCard.new(icc_data: '50074D41455354524F571167999989000018123D25122200835506065A0967999989000018123F5F20134D54495032362D204D41455354524F203132415F24032512315F280200565F2A0208405F300202205F340101820278008407A0000000043060950500000080009A031504219B02E8009C01009F02060000000010009F03060000000000009F0607A00000000430609F090200029F10120210A7800F040000000000000000000000FF9F12074D61657374726F9F1A0208409F1C0831303030333331369F1E0831303030333331369F2608460245B808BCA1369F2701809F3303E0B8C89F34034403029F3501229F360200279F3704EA2C3A7A9F410400000094DF280104DFAE5711679999FFFFFFF8123D2512220083550606DFAE5A09679999FFFFFFF8123F')
+    }
+
+    @options = {
+      :currency => "USD",
+      :description => 'ActiveMerchant Test Purchase',
+      :email => 'wow@example.com'
+    }
+  end
+
+  # for EMV contact transactions, it's advised to do a separate auth + capture
+  # to satisfy the EMV chip's transaction flow, but this works as a legal
+  # API call. You shouldn't use it in a real EMV implementation, though.
+  def test_successful_purchase_with_emv_credit_card_in_uk
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_uk))
+    assert response = @gateway.purchase(@amount, @emv_credit_cards[:uk], @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  # perform separate auth & capture rather than a purchase in practice for the
+  # reasons mentioned above.
+  def test_successful_purchase_with_emv_credit_card_in_us
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
+    assert response = @gateway.purchase(@amount, @emv_credit_cards[:us], @options)
+    assert_success response
+    assert_equal "charge", response.params["object"]
+    assert response.params["paid"]
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  def test_authorization_and_capture_with_emv_credit_card_in_uk
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_uk))
+    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:uk], @options)
+    assert_success authorization
+    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
+    refute authorization.params["captured"]
+
+    assert capture = @gateway.capture(@amount, authorization.authorization)
+    assert_success capture
+    assert capture.emv_authorization, "Capture should contain emv_authorization containing the EMV TC"
+  end
+
+  def test_authorization_and_capture_with_emv_credit_card_in_us
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
+    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options)
+    assert_success authorization
+    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
+    refute authorization.params["captured"]
+
+    assert capture = @gateway.capture(@amount, authorization.authorization)
+    assert_success capture
+    assert capture.emv_authorization, "Capture should contain emv_authorization containing the EMV TC"
+  end
+
+  def test_authorization_and_void_with_emv_credit_card_in_us
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
+    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options)
+    assert_success authorization
+    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
+    refute authorization.params["captured"]
+
+    assert void = @gateway.void(authorization.authorization)
+    assert_success void
+  end
+
+  def test_authorization_and_void_with_emv_credit_card_in_uk
+    @gateway = StripeGateway.new(fixtures(:stripe_emv_uk))
+    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:uk], @options)
+    assert_success authorization
+    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
+    refute authorization.params["captured"]
+
+    assert void = @gateway.void(authorization.authorization)
+    assert_success void
+  end
+
+end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -1,33 +1,19 @@
 require 'test_helper'
 
 class RemoteStripeTest < Test::Unit::TestCase
-  CHARGE_ID_REGEX = /ch_[a-zA-Z\d]+/
-
   def setup
     @gateway = StripeGateway.new(fixtures(:stripe))
-    @currency = fixtures(:stripe)["currency"]
 
     @amount = 100
     @credit_card = credit_card('4242424242424242')
     @declined_card = credit_card('4000000000000002')
     @new_credit_card = credit_card('5105105105105100')
 
-    @emv_credit_cards = {
-      uk: ActiveMerchant::Billing::CreditCard.new(icc_data: '500B56495341204352454449545F201A56495341204143515549524552205445535420434152442030315F24031512315F280208405F2A0208265F300202015F34010182025C008407A0000000031010950502000080009A031408259B02E8009C01009F02060000000734499F03060000000000009F0607A00000000310109F0902008C9F100706010A03A080009F120F4352454449544F20444520564953419F1A0208269F1C0831373030303437309F1E0831373030303437309F2608EB2EC0F472BEA0A49F2701809F3303E0B8C89F34031E03009F3501229F360200C39F37040A27296F9F4104000001319F4502DAC5DFAE5711476173FFFFFF0119D15122011758989389DFAE5A08476173FFFFFF011957114761739001010119D151220117589893895A084761739001010119'),
-      us: ActiveMerchant::Billing::CreditCard.new(icc_data: '50074D41455354524F571167999989000018123D25122200835506065A0967999989000018123F5F20134D54495032362D204D41455354524F203132415F24032512315F280200565F2A0208405F300202205F340101820278008407A0000000043060950500000080009A031504219B02E8009C01009F02060000000010009F03060000000000009F0607A00000000430609F090200029F10120210A7800F040000000000000000000000FF9F12074D61657374726F9F1A0208409F1C0831303030333331369F1E0831303030333331369F2608460245B808BCA1369F2701809F3303E0B8C89F34034403029F3501229F360200279F3704EA2C3A7A9F410400000094DF280104DFAE5711679999FFFFFFF8123D2512220083550606DFAE5A09679999FFFFFFF8123F')
-    }
-
     @options = {
-      :currency => @currency,
+      :currency => "USD",
       :description => 'ActiveMerchant Test Purchase',
       :email => 'wow@example.com'
     }
-    @apple_pay_payment_token = apple_pay_payment_token
-  end
-
-  def test_dump_transcript
-    omit("Transcript scrubbing for this gateway has been tested.")
-    dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
   end
 
   def test_transcript_scrubbing
@@ -50,16 +36,6 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal "wow@example.com", response.params["metadata"]["email"]
   end
 
-  def test_successful_purchase_with_apple_pay_payment_token
-    assert response = @gateway.purchase(@amount, @apple_pay_payment_token, @options)
-    assert_success response
-    assert_equal "charge", response.params["object"]
-    assert response.params["paid"]
-    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
-    assert_equal "wow@example.com", response.params["metadata"]["email"]
-    assert_match CHARGE_ID_REGEX, response.authorization
-  end
-
   def test_successful_purchase_with_recurring_flag
     custom_options = @options.merge(:eci => 'recurring')
     assert response = @gateway.purchase(@amount, @credit_card, custom_options)
@@ -75,22 +51,11 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_failure response
     assert_match %r{Your card was declined}, response.message
     assert_match Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
-    assert_match CHARGE_ID_REGEX, response.authorization
+    assert_match /ch_[a-zA-Z\d]+/, response.authorization
   end
 
   def test_authorization_and_capture
     assert authorization = @gateway.authorize(@amount, @credit_card, @options)
-    assert_success authorization
-    refute authorization.params["captured"]
-    assert_equal "ActiveMerchant Test Purchase", authorization.params["description"]
-    assert_equal "wow@example.com", authorization.params["metadata"]["email"]
-
-    assert capture = @gateway.capture(@amount, authorization.authorization)
-    assert_success capture
-  end
-
-  def test_authorization_and_capture_with_apple_pay_payment_token
-    assert authorization = @gateway.authorize(@amount, @apple_pay_payment_token, @options)
     assert_success authorization
     refute authorization.params["captured"]
     assert_equal "ActiveMerchant Test Purchase", authorization.params["description"]
@@ -109,25 +74,8 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_success void
   end
 
-  def test_authorization_and_void_with_apple_pay_payment_token
-    assert authorization = @gateway.authorize(@amount, @apple_pay_payment_token, @options)
-    assert_success authorization
-    refute authorization.params["captured"]
-
-    assert void = @gateway.void(authorization.authorization)
-    assert_success void
-  end
-
   def test_successful_void
     assert response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_success response
-    assert response.authorization
-    assert void = @gateway.void(response.authorization)
-    assert_success void
-  end
-
-  def test_successful_void_with_apple_pay_payment_token
-    assert response = @gateway.purchase(@amount, @apple_pay_payment_token, @options)
     assert_success response
     assert response.authorization
     assert void = @gateway.void(response.authorization)
@@ -172,7 +120,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    assert response = @gateway.store(@credit_card, {:currency => @currency, :description => "Active Merchant Test Customer", :email => "email@example.com"})
+    assert response = @gateway.store(@credit_card, {:description => "Active Merchant Test Customer", :email => "email@example.com"})
     assert_success response
     assert_equal "customer", response.params["object"]
     assert_equal "Active Merchant Test Customer", response.params["description"]
@@ -182,49 +130,17 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal @credit_card.last_digits, first_card["last4"]
   end
 
-  def test_successful_store_with_apple_pay_payment_token
-    assert response = @gateway.store(@apple_pay_payment_token, {:currency => @currency, :description => "Active Merchant Test Customer", :email => "email@example.com"})
-    assert_success response
-    assert_equal "customer", response.params["object"]
-    assert_equal "Active Merchant Test Customer", response.params["description"]
-    assert_equal "email@example.com", response.params["email"]
-    first_card = response.params["cards"]["data"].first
-    assert_equal response.params["default_card"], first_card["id"]
-    assert_equal "4242", first_card["dynamic_last4"] # when stripe is in test mode, token exchanged will return a test card with dynamic_last4 4242
-    assert_equal "0000", first_card["last4"] # last4 is 0000 when using an apple pay token
-  end
-
   def test_successful_store_with_existing_customer
-    assert response = @gateway.store(@credit_card, {:currency => @currency, :description => "Active Merchant Test Customer"})
+    assert response = @gateway.store(@credit_card, {:description => "Active Merchant Test Customer"})
     assert_success response
 
-    assert response = @gateway.store(@new_credit_card, {:customer => response.params['id'], :currency => @currency, :description => "Active Merchant Test Customer", :email => "email@example.com"})
+    assert response = @gateway.store(@new_credit_card, {:customer => response.params['id'], :description => "Active Merchant Test Customer", :email => "email@example.com"})
     assert_success response
     assert_equal 2, response.responses.size
 
     card_response = response.responses[0]
     assert_equal "card", card_response.params["object"]
     assert_equal @new_credit_card.last_digits, card_response.params["last4"]
-
-    customer_response = response.responses[1]
-    assert_equal "customer", customer_response.params["object"]
-    assert_equal "Active Merchant Test Customer", customer_response.params["description"]
-    assert_equal "email@example.com", customer_response.params["email"]
-    assert_equal 2, customer_response.params["cards"]["count"]
-  end
-
-  def test_successful_store_with_existing_customer_and_apple_pay_payment_token
-    assert response = @gateway.store(@credit_card, {:currency => @currency, :description => "Active Merchant Test Customer"})
-    assert_success response
-
-    assert response = @gateway.store(@apple_pay_payment_token, {:customer => response.params['id'], :currency => @currency, :description => "Active Merchant Test Customer", :email => "email@example.com"})
-    assert_success response
-    assert_equal 2, response.responses.size
-
-    card_response = response.responses[0]
-    assert_equal "card", card_response.params["object"]
-    assert_equal "4242", card_response.params["dynamic_last4"] # when stripe is in test mode, token exchanged will return a test card with dynamic_last4 4242
-    assert_equal "0000", card_response.params["last4"] # last4 is 0000 when using an apple pay token
 
     customer_response = response.responses[1]
     assert_equal "customer", customer_response.params["object"]
@@ -261,29 +177,11 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert response.params["paid"]
   end
 
-  def test_successful_recurring_with_apple_pay_payment_token
-    assert response = @gateway.store(@apple_pay_payment_token, {:description => "Active Merchant Test Customer", :email => "email@example.com"})
-    assert_success response
-    assert recharge_options = @options.merge(:customer => response.params["id"])
-    assert response = @gateway.purchase(@amount, nil, recharge_options)
-    assert_success response
-    assert_equal "charge", response.params["object"]
-    assert response.params["paid"]
-  end
-
   def test_invalid_login
     gateway = StripeGateway.new(:login => 'active_merchant_test')
     assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_match "Invalid API Key provided", response.message
-  end
-
-  def test_application_fee_for_stripe_connect
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12 ))
-    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
-    assert response.params['fee_details'].any? do |fee|
-      (fee['type'] == 'application_fee') && (fee['amount'] == 12)
-    end
   end
 
   def test_card_present_purchase
@@ -302,21 +200,6 @@ class RemoteStripeTest < Test::Unit::TestCase
 
     assert capture = @gateway.capture(@amount, authorization.authorization)
     assert_success capture
-  end
-
-  def test_successful_refund_with_application_fee
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
-    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
-    assert refund = @gateway.refund(@amount, response.authorization, :refund_application_fee => true)
-    assert_success refund
-    assert_equal 0, refund.params["fee"]
-  end
-
-  def test_refund_partial_application_fee
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:application_fee => 12))
-    assert response.params['fee_details'], 'This test will only work if your gateway login is a Stripe Connect access_token.'
-    assert refund = @gateway.refund(@amount - 20, response.authorization, { :refund_fee_amount => 10 })
-    assert_success refund
   end
 
   def test_creditcard_purchase_with_customer
@@ -405,111 +288,4 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_match Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
   end
 
-  def test_purchase_with_unsuccessful_apple_pay_token_exchange
-    assert response = @gateway.purchase(@amount, ApplePayPaymentToken.new('garbage'), @options)
-    assert_failure response
-  end
-
-  def test_successful_purchase_with_apple_pay_raw_cryptogram
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
-      verification_value: nil
-    )
-    assert response = @gateway.purchase(@amount, credit_card, @options)
-    assert_success response
-    assert_equal "charge", response.params["object"]
-    assert response.params["paid"]
-    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
-    assert_equal "wow@example.com", response.params["metadata"]["email"]
-    assert_match CHARGE_ID_REGEX, response.authorization
-  end
-
-  def test_successful_auth_with_apple_pay_raw_cryptogram
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: "EHuWW9PiBkWvqE5juRwDzAUFBAk=",
-      verification_value: nil
-    )
-    assert response = @gateway.authorize(@amount, credit_card, @options)
-    assert_success response
-    assert_equal "charge", response.params["object"]
-    assert response.params["paid"]
-    assert_equal "ActiveMerchant Test Purchase", response.params["description"]
-    assert_equal "wow@example.com", response.params["metadata"]["email"]
-    assert_match CHARGE_ID_REGEX, response.authorization
-  end
-
-  # for EMV contact transactions, it's advised to do a separate auth + capture
-  # to satisfy the EMV chip's transaction flow, but this works as a legal
-  # API call. You shouldn't use it in a real EMV implementation, though.
-  def test_successful_purchase_with_emv_credit_card_in_uk
-    omit("Disabled until EMV APIs are officially live.")
-    @gateway = StripeGateway.new(fixtures(:stripe_emv_uk))
-    assert response = @gateway.purchase(@amount, @emv_credit_cards[:uk], @options)
-    assert_success response
-    assert_equal "charge", response.params["object"]
-    assert response.params["paid"]
-    assert_match CHARGE_ID_REGEX, response.authorization
-  end
-
-  # perform separate auth & capture rather than a purchase in practice for the
-  # reasons mentioned above.
-  def test_successful_purchase_with_emv_credit_card_in_us
-    omit("Disabled until EMV APIs are officially live.")
-    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
-    assert response = @gateway.purchase(@amount, @emv_credit_cards[:us], @options)
-    assert_success response
-    assert_equal "charge", response.params["object"]
-    assert response.params["paid"]
-    assert_match CHARGE_ID_REGEX, response.authorization
-  end
-
-  def test_authorization_and_capture_with_emv_credit_card_in_uk
-    omit("Disabled until EMV APIs are officially live.")
-    @gateway = StripeGateway.new(fixtures(:stripe_emv_uk))
-    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:uk], @options)
-    assert_success authorization
-    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
-    refute authorization.params["captured"]
-
-    assert capture = @gateway.capture(@amount, authorization.authorization)
-    assert_success capture
-    assert capture.emv_authorization, "Capture should contain emv_authorization containing the EMV TC"
-  end
-
-  def test_authorization_and_capture_with_emv_credit_card_in_us
-    omit("Disabled until EMV APIs are officially live.")
-    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
-    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options)
-    assert_success authorization
-    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
-    refute authorization.params["captured"]
-
-    assert capture = @gateway.capture(@amount, authorization.authorization)
-    assert_success capture
-    assert capture.emv_authorization, "Capture should contain emv_authorization containing the EMV TC"
-  end
-
-  def test_authorization_and_void_with_emv_credit_card_in_us
-    omit("Disabled until EMV APIs are officially live.")
-    @gateway = StripeGateway.new(fixtures(:stripe_emv_us))
-    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options)
-    assert_success authorization
-    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
-    refute authorization.params["captured"]
-
-    assert void = @gateway.void(authorization.authorization)
-    assert_success void
-  end
-
-  def test_authorization_and_void_with_emv_credit_card_in_uk
-    omit("Disabled until EMV APIs are officially live.")
-    @gateway = StripeGateway.new(fixtures(:stripe_emv_uk))
-    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:uk], @options)
-    assert_success authorization
-    assert authorization.emv_authorization, "Authorization should contain emv_authorization containing the EMV ARPC"
-    refute authorization.params["captured"]
-
-    assert void = @gateway.void(authorization.authorization)
-    assert_success void
-  end
 end


### PR DESCRIPTION
The EMV API isn't yet publicly available and @bizla mentioned that Apple
pay tokens have a 24 hour lifetime.  In addition, the Stripe Connect
tests only work if your login is a Stripe Connect access token.

Now the remote stripe tests are all passing and the EMV, apple, and
Stripe Connect tests are each in their own test file so they can be run
separately.

This is for #1664.