### PR TITLE
[POSSIBLE BREAKAGE] Stripe: Make version explicit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Vanco: Allow specification of fund_id [duff]
 * S5: Add gateway [davidsantoso]
 * SecureNet: Truncate order_id [duff]
+* [POSSIBLE BREAKAGE] Stripe: Be explicit about API version [duff]
 
 
 == Version 1.49.0 (May 1, 2015)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -49,7 +49,6 @@ module ActiveMerchant #:nodoc:
         requires!(options, :login)
         @api_key = options[:login]
         @fee_refund_api_key = options[:fee_refund_login]
-        @version = options[:version]
 
         super
       end
@@ -243,7 +242,7 @@ module ActiveMerchant #:nodoc:
           add_customer_data(post, options)
           add_metadata(post, options)
           post[:description] = options[:description]
-          post[:statement_description] = options[:statement_description]
+          post[:statement_descriptor] = options[:statement_description]
           add_customer(post, payment, options)
           add_flags(post, options)
         end
@@ -381,18 +380,21 @@ module ActiveMerchant #:nodoc:
 
       def headers(options = {})
         key     = options[:key] || @api_key
-        version = options[:version] || @version
         idempotency_key = options[:idempotency_key]
 
         headers = {
           "Authorization" => "Basic " + Base64.encode64(key.to_s + ":").strip,
           "User-Agent" => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+          "Stripe-Version" => api_version(options),
           "X-Stripe-Client-User-Agent" => user_agent,
           "X-Stripe-Client-User-Metadata" => {:ip => options[:ip]}.to_json
         }
-        headers.merge!("Stripe-Version" => version) if version
         headers.merge!("Idempotency-Key" => idempotency_key) if idempotency_key
         headers
+      end
+
+      def api_version(options)
+        options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -281,7 +281,7 @@ class StripeTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, statement_description: '5K RACE TICKET')
     end.check_request do |method, endpoint, data, headers|
-      assert_match(/statement_description=5K\+RACE\+TICKET/, data)
+      assert_match(/statement_descriptor=5K\+RACE\+TICKET/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Stripe has many API versions, some of which are breaking changes:

https://stripe.com/docs/upgrades#api-changelog

If someone today created a new Stripe account, the remote tests would
not pass because Stripe has changed some of the attribute responses around
`cards` (used by our `store` method):

https://stripe.com/docs/upgrades#2015-02-18

In addition, the `statement_description` no longer works since it's been
replaced by `statement_descriptor`.  Clients of Active Merchant may be
using `statement_description` so we're now mapping that to
`statement_descriptor` under the covers.

So how do we solve these issues?  This commit makes the specification of
the Stripe API version explicit in the headers.  Previously, you could
specify the version you wanted to use for a particular transaction.  Or,
you could specify it when you instantiated the gateway.  In this commit,
we still allow such customizations.  If no version is specified though,
we explicitly use the current latest version (2015-04-07).

This improves things such that if Stripe releases a new, breaking API
version, clients using Active Merchant won't be broken.  If we want to
upgrade to the default version Active Merchant uses, we can do so
explicitly and change the underlying options we're passing accordingly.

If you're already specifying the Stripe API version, then this commit
shouldn't break you.  If you're relying on the default API version of
the underlying Stripe account, there may be issues which we'll fix as we
learn of them.