### PR TITLE
USA ePay gateway will now indicate a manual entry

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -138,6 +138,15 @@ module ActiveMerchant #:nodoc:
       # @return [String]
       attr_accessor :track_data
 
+      # Returns or sets whether a card has been processed using manual entry.
+      #
+      # This attribute is optional and is only used by gateways who use this information in their transaction risk
+      # calculations. See {this page on 'card not present' transactions}[http://en.wikipedia.org/wiki/Card_not_present_transaction]
+      # for further explanation and examples of this kind of transaction.
+      #
+      # @return [true, false]
+      attr_accessor :manual_entry
+
       # Returns or sets the ICC/ASN1 credit card data for a EMV transaction, typically this is a BER-encoded TLV string.
       #
       # @return [String]

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -178,7 +178,8 @@ module ActiveMerchant #:nodoc:
           post[:card]   = credit_card.number
           post[:cvv2]   = credit_card.verification_value if credit_card.verification_value?
           post[:expir]  = expdate(credit_card)
-          post[:name]   = credit_card.name
+          post[:name]   = credit_card.name unless credit_card.name.blank?
+          post[:cardpresent] = true if credit_card.manual_entry
         end
       end
 
@@ -256,4 +257,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -3,15 +3,15 @@ require 'test_helper'
 class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
   def setup
     @gateway = UsaEpayTransactionGateway.new(fixtures(:usa_epay))
-    @creditcard = credit_card('4000100011112224')
+    @credit_card = credit_card('4000100011112224')
     @declined_card = credit_card('4000300011112220')
     @credit_card_with_track_data = credit_card_with_track_data('4000100011112224')
-    @options = { :billing_address => address(:zip => "27614", :state => "NC") }
+    @options = { :billing_address => address(:zip => "27614", :state => "NC")}
     @amount = 100
   end
 
   def test_successful_purchase
-    assert response = @gateway.purchase(@amount, @creditcard, @options)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Success', response.message
     assert_success response
   end
@@ -22,8 +22,22 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_authorization_with_manual_entry
+    @credit_card.manual_entry = true
+    assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_equal 'Success', response.message
+    assert_success response
+  end
+
+   def test_successful_purchase_with_manual_entry
+    @credit_card.manual_entry = true
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_equal 'Success', response.message
+    assert_success response
+   end
+
   def test_successful_purchase_with_extra_details
-    assert response = @gateway.purchase(@amount, @creditcard, @options.merge(:order_id => generate_unique_id, :description => "socool"))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(:order_id => generate_unique_id, :description => "socool"))
     assert_equal 'Success', response.message
     assert_success response
   end
@@ -35,11 +49,11 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @declined_card, @options.merge(:order_id => generate_unique_id))
     assert_failure response
     assert_match(/declined/i, response.message)
-    assert Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code 
+    assert Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
   end
 
   def test_authorize_and_capture
-    assert auth = @gateway.authorize(@amount, @creditcard, @options)
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert_equal 'Success', auth.message
     assert auth.authorization
@@ -54,7 +68,7 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    assert response = @gateway.purchase(@amount, @creditcard, @options)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert response.authorization
     assert refund = @gateway.refund(@amount - 20, response.authorization)
@@ -76,7 +90,7 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
   end
 
   def test_successful_void
-    assert response = @gateway.purchase(@amount, @creditcard, @options)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert response.authorization
     assert void = @gateway.void(response.authorization)
@@ -90,7 +104,7 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
   end
 
   def test_successful_void_release
-    assert response = @gateway.purchase(@amount, @creditcard, @options)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert response.authorization
     assert void = @gateway.void(response.authorization, void_mode: :void_release)
@@ -105,13 +119,13 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_invalid_key
     gateway = UsaEpayTransactionGateway.new(:login => '')
-    assert response = gateway.purchase(@amount, @creditcard, @options)
+    assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Specified source key not found.', response.message
     assert_failure response
   end
 
   def test_successful_verify
-    assert response = @gateway.verify(@creditcard, @options)
+    assert response = @gateway.verify(@credit_card, @options)
     assert_success response
     assert_equal "Success", response.message
     assert_success response.responses.last, "The void should succeed"

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -187,6 +187,20 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     end
   end
 
+  def test_manual_entry_is_properly_indicated_on_purchase
+    @credit_card.manual_entry = true
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+
+      assert_match %r{UMcard=4242424242424242},  data
+      assert_match %r{UMcardpresent=true},       data
+
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_does_not_raise_error_on_missing_values
     @gateway.expects(:ssl_post).returns("status")
     assert_nothing_raised do


### PR DESCRIPTION
Based on the requirements outlined in this email:

> From: Vlad Galyuz <vladg@usaepay.com>
> ...
> 2) You can set the card present flag and place the card number in the credit card field instead of the swipe field and that will indicate that it was manual entry.

@andrewpaliga @girasquid 

