### PR TITLE
S5: Remove address requirement for purchase and authorize

### DIFF
--- a/lib/active_merchant/billing/gateways/s5.rb
+++ b/lib/active_merchant/billing/gateways/s5.rb
@@ -126,7 +126,7 @@ module ActiveMerchant #:nodoc:
           xml.Contact do
             xml.Email      options[:email]
             xml.Ip         options[:ip]
-            xml.Phone      address[:phone]
+            xml.Phone      address[:phone] if address
           end
           xml.Address do
             xml.Street     "#{address[:address1]} #{address[:address2]}"
@@ -134,7 +134,7 @@ module ActiveMerchant #:nodoc:
             xml.City       address[:city]
             xml.State      address[:state]
             xml.Country    address[:country]
-          end
+          end if address
           xml.Name do
             xml.Given      creditcard.first_name
             xml.Family     creditcard.last_name

--- a/test/remote/gateways/remote_s5_test.rb
+++ b/test/remote/gateways/remote_s5_test.rb
@@ -32,11 +32,22 @@ class RemoteS5Test < Test::Unit::TestCase
     assert_match %r{Request successfully processed}, response.message
   end
 
+  def test_successful_purchase_without_address
+    response = @gateway.purchase(@amount, @credit_card, {})
+    assert_success response
+    assert_match %r{Request successfully processed}, response.message
+  end
+
   def test_failed_purchase
     @options[:memo] = "800.100.151"
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 'transaction declined (invalid card)', response.message
+  end
+
+  def test_successful_authorize_without_address
+    auth = @gateway.authorize(@amount, @credit_card, {})
+    assert_success auth
   end
 
   def test_successful_authorize_and_capture


### PR DESCRIPTION
@duff quick fix for the S5 gateway. Add the customer info if it's passed in the options hash via `billing_address` or just `address`. Otherwise, don't add it to the XML.