### PR TITLE
S5: Include card brand in request body

### DIFF
--- a/lib/active_merchant/billing/gateways/s5.rb
+++ b/lib/active_merchant/billing/gateways/s5.rb
@@ -115,6 +115,7 @@ module ActiveMerchant #:nodoc:
         xml.Account do
           xml.Number        creditcard.number
           xml.Holder        "#{creditcard.first_name} #{creditcard.last_name}"
+          xml.Brand         creditcard.brand
           xml.Expiry(year: creditcard.year, month: creditcard.month)
           xml.Verification  creditcard.verification_value
         end


### PR DESCRIPTION
@duff small change to add the credit card brand in S5 request body.

In terms of a remote test: it's a bit of an odd ball since it's not a validation that's run in sandbox, but it is in production. In sandbox, S5 will always return a success so I'd have to manually include the return code in the `<Memo>` tag to generate the error. At that point, it seems as though the test is only asserting that I issued the correct error code in the `<Memo>` tag as opposed to actually testing that validation.

Thoughts?