### PR TITLE
Litle Gateway: Enhancements to error handling and tokenization

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -264,6 +264,12 @@ module ActiveMerchant #:nodoc:
           end
         end
 
+        if parsed.empty?
+          %w(response message).each do |attribute|
+            parsed[attribute.to_sym] = doc.xpath("//litleOnlineResponse").attribute(attribute).value
+          end
+        end
+
         parsed
       end
 

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -109,6 +109,7 @@ module ActiveMerchant #:nodoc:
           doc.registerTokenRequest(transaction_attributes(options)) do
             doc.orderId(truncate(options[:order_id], 24))
             doc.accountNumber(creditcard.number)
+            doc.cardValidationNum(creditcard.verification_value) if creditcard.verification_value
           end
         end
 

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -256,4 +256,13 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_unsuccessful_xml_schema_validation
+    credit_card = CreditCard.new(@credit_card_hash.merge(:number => '123456'))
+    assert store_response = @gateway.store(credit_card, :order_id => '51')
+
+    assert_failure store_response
+    assert_match(/^Error validating xml data against the schema/, store_response.message)
+    assert_equal '1', store_response.params['response']
+  end
+
 end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -273,6 +273,16 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_unsuccessful_xml_schema_validation
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(unsuccessful_xml_schema_validation_response)
+
+    assert_failure response
+    assert_match(/^Error validating xml data against the schema/, response.message)
+    assert_equal "1", response.params["response"]
+  end
+
   private
 
   def successful_purchase_response
@@ -483,6 +493,15 @@ class LitleTest < Test::Unit::TestCase
           <message>Credit card number was invalid</message>
         </registerTokenResponse>
       </litleOnlineResponse>
+    )
+  end
+
+  def unsuccessful_xml_schema_validation_response
+    %(
+    <litleOnlineResponse version='8.29' xmlns='http://www.litle.com/schema'
+                     response='1'
+                     message='Error validating xml data against the schema on line 8\nthe length of the value is 10, but the required minimum is 13.'/>
+
     )
   end
 


### PR DESCRIPTION
- When a Litle request fails due to an XML schema validation error, currently the error message is silently lost and not surfaced in the response object returned. I've fixed this issue by surfacing the `response` and `message` attributes of the top level `litleOnlineResponse` node in the response object.

- Litle allows passing the credit card verification value with tokenization requests as per their documentation (Litle_XML_Reference_Guide_XML8.14_V2.27.pdf: Pg 189):

 > When you submit the CVV2/CVC2/CID in a registerTokenRequest, the Litle platform encrypts and stores the value on a temporary basis for later use in a tokenized Auth/Sale transaction submitted without the value. This is done to accommodate merchant systems/workflows where the security code is available at the time of token registration, but not at the time of the Auth/Sale.

I've added support for this.
