### PR TITLE
BPoint gateway - pass biller_code as arg from public method options

### DIFF
--- a/lib/active_merchant/billing/gateways/bpoint.rb
+++ b/lib/active_merchant/billing/gateways/bpoint.rb
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
       def purchase(amount, credit_card, options={})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
-            add_purchase(payment_xml, amount, credit_card)
+            add_purchase(payment_xml, amount, credit_card, options)
           end
         end
         commit(request_body)
@@ -37,25 +37,25 @@ module ActiveMerchant #:nodoc:
       def authorize(amount, credit_card, options={})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
-            add_authorize(payment_xml, amount, credit_card)
+            add_authorize(payment_xml, amount, credit_card, options)
           end
         end
         commit(request_body)
       end
 
-      def capture(amount, authorization)
+      def capture(amount, authorization, options={})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
-            add_capture(payment_xml, amount, authorization)
+            add_capture(payment_xml, amount, authorization, options)
           end
         end
         commit(request_body)
       end
 
-      def refund(amount, authorization)
+      def refund(amount, authorization, options={})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
-            add_refund(payment_xml, amount, authorization)
+            add_refund(payment_xml, amount, authorization, options)
           end
         end
         commit(request_body)
@@ -64,7 +64,7 @@ module ActiveMerchant #:nodoc:
       def void(amount, authorization, options={})
         request_body = soap_request do |xml|
           process_payment(xml) do |payment_xml|
-            add_void(payment_xml, amount, authorization)
+            add_void(payment_xml, amount, authorization, options)
           end
         end
         commit(request_body)
@@ -134,35 +134,35 @@ module ActiveMerchant #:nodoc:
         xml.send('merchantNumber', @options[:merchant_number])
       end
 
-      def add_purchase(xml, amount, credit_card)
-        payment_xml(xml, 'PAYMENT', amount)
+      def add_purchase(xml, amount, credit_card, options)
+        payment_xml(xml, 'PAYMENT', amount, options)
         credit_card_xml(xml, credit_card)
       end
 
-      def add_authorize(xml, amount, credit_card)
-        payment_xml(xml, 'PREAUTH', amount)
+      def add_authorize(xml, amount, credit_card, options)
+        payment_xml(xml, 'PREAUTH', amount, options)
         credit_card_xml(xml, credit_card)
       end
 
-      def add_capture(xml, amount, transaction_number)
-        payment_xml(xml, 'CAPTURE', amount)
+      def add_capture(xml, amount, transaction_number, options)
+        payment_xml(xml, 'CAPTURE', amount, options)
         transaction_number_xml(xml, transaction_number)
       end
 
-      def add_refund(xml, amount, transaction_number)
-        payment_xml(xml, 'REFUND', amount)
+      def add_refund(xml, amount, transaction_number, options)
+        payment_xml(xml, 'REFUND', amount, options)
         transaction_number_xml(xml, transaction_number)
       end
 
-      def add_void(xml, amount, transaction_number)
-        payment_xml(xml, 'REVERSAL', amount)
+      def add_void(xml, amount, transaction_number, options)
+        payment_xml(xml, 'REVERSAL', amount, options)
         transaction_number_xml(xml, transaction_number)
       end
 
-      def payment_xml(xml, payment_type, amount)
+      def payment_xml(xml, payment_type, amount, options)
         xml.send('PaymentType', payment_type)
         xml.send('TxnType', 'WEB_SHOP')
-        xml.send('BillerCode', @options.fetch(:biller_code, ''))
+        xml.send('BillerCode', options.fetch(:biller_code, ''))
         xml.send('MerchantReference', '')
         xml.send('CRN1', '')
         xml.send('CRN2', '')

--- a/test/unit/gateways/bpoint_test.rb
+++ b/test/unit/gateways/bpoint_test.rb
@@ -7,8 +7,7 @@ class BpointTest < Test::Unit::TestCase
     @gateway = BpointGateway.new(
       username: '',
       password: '',
-      merchant_number: '',
-      biller_code: ''
+      merchant_number: ''
     )
 
     @credit_card = credit_card
@@ -121,6 +120,14 @@ class BpointTest < Test::Unit::TestCase
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  def test_passing_biller_code
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, { biller_code: '1234' })
+    end.check_request do |endpoint, data, headers|
+      assert_match(%r(<BillerCode>1234</BillerCode>)m, data)
+    end.respond_with(successful_authorize_response)
   end
 
   private


### PR DESCRIPTION
Previously, the code that constructs payment XML was pulling `biller_code` from
options passed to `initialize`, but now each public method that takes options
that result in a call to ProcessPayment in the BPoint API will accept options
for `biller_code`.