### PR TITLE
Litle Gateway: Ability to optionally use paypage_registration_id 

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -203,7 +203,7 @@ module ActiveMerchant #:nodoc:
         return if payment_method.is_a?(String)
 
         doc.billToAddress do
-          doc.name(payment_method.is_a?(Hash) ? options[:billing_address][:name] : payment_method.name)
+          doc.name(payment_method.respond_to?(:name) ? payment_method.name : options[:billing_address][:name])
           doc.email(options[:email]) if options[:email]
           add_address(doc, options[:billing_address])
         end

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -183,6 +183,12 @@ module ActiveMerchant #:nodoc:
           doc.card do
             doc.track(payment_method.track_data)
           end
+        elsif payment_method.is_a?(Hash)
+          doc.paypage do
+            doc.paypageRegistrationId(payment_method[:paypage_registration_id])
+            doc.expDate(payment_method[:exp_date])
+            doc.cardValidationNum(payment_method[:card_validation_num])
+          end
         else
           doc.card do
             doc.type_(CARD_TYPE[payment_method.brand])
@@ -197,15 +203,14 @@ module ActiveMerchant #:nodoc:
         return if payment_method.is_a?(String)
 
         doc.billToAddress do
-          doc.name(payment_method.name)
+          doc.name(payment_method.is_a?(Hash) ? options[:billing_address][:name] : payment_method.name)
           doc.email(options[:email]) if options[:email]
-
           add_address(doc, options[:billing_address])
         end
       end
 
       def add_shipping_address(doc, payment_method, options)
-        return if payment_method.is_a?(String)
+        return if payment_method.is_a?(String) || payment_method.is_a?(Hash)
 
         doc.shipToAddress do
           add_address(doc, options[:shipping_address])
@@ -276,7 +281,6 @@ module ActiveMerchant #:nodoc:
           :avs_result => { :code => AVS_RESPONSE_CODE[parsed[:fraudResult_avsResult]] },
           :cvv_result => parsed[:fraudResult_cardValidationResult]
         }
-
         Response.new(success_from(kind, parsed), parsed[:message], parsed, options)
       end
 

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -187,7 +187,7 @@ module ActiveMerchant #:nodoc:
           doc.paypage do
             doc.paypageRegistrationId(payment_method[:paypage_registration_id])
             doc.expDate(payment_method[:exp_date])
-            doc.cardValidationNum(payment_method[:card_validation_num])
+            doc.cardValidationNum(payment_method[:card_validation_num]) unless payment_method[:card_validation_num].blank?
           end
         else
           doc.card do

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -17,6 +17,7 @@ class RemoteLitleTest < Test::Unit::TestCase
       order_id: '1',
       email: 'wow@example.com',
       billing_address: {
+        name: 'Joe Green',
         company: 'testCompany',
         address1: '1 Main St.',
         city: 'Burlington',
@@ -130,6 +131,17 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', void.message
   end
 
+  def test_successful_authorization_with_paypage
+    paypage_payment_method = {
+      paypage_registration_id: "cDZJcmd1VjNlYXNaSlRMTGpocVZQY1NNlYE4ZW5UTko4NU9KK3p1L1p1VzE4ZWVPQVlSUHNITG1JN2I0NzlyTg=",
+      exp_date: "1012",
+      card_validation_num: "000"
+    }
+    assert auth = @gateway.authorize(40000, paypage_payment_method, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+  end
+  
   def test_void_authorization
     assert auth = @gateway.authorize(10010, @credit_card1, @options)
 

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -134,8 +134,7 @@ class RemoteLitleTest < Test::Unit::TestCase
   def test_successful_authorization_with_paypage
     paypage_payment_method = {
       paypage_registration_id: "cDZJcmd1VjNlYXNaSlRMTGpocVZQY1NNlYE4ZW5UTko4NU9KK3p1L1p1VzE4ZWVPQVlSUHNITG1JN2I0NzlyTg=",
-      exp_date: "1012",
-      card_validation_num: "000"
+      exp_date: "1012"
     }
     assert auth = @gateway.authorize(40000, paypage_payment_method, @options)
     assert_success auth

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -118,10 +118,11 @@ class LitleTest < Test::Unit::TestCase
       card_validation_num: "000"
     }
     response = stub_comms do
-       @gateway.authorize(@amount, paypage_payment_method)
+       @gateway.authorize(@amount, paypage_payment_method, { billing_address: { name: 'John Green' }} )
     end.respond_with(successful_authorize_with_paypage_response)
 
     assert_success response
+    assert_equal "1234567890123456", response.params["tokenResponse_litleToken"]
     assert_equal "100000000000000001;authorization", response.authorization
     assert response.test?
   end
@@ -350,7 +351,7 @@ class LitleTest < Test::Unit::TestCase
     %(
       <litleOnlineResponse version='9.3' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
         <authorizationResponse id='ididid' reportGroup='rtpGrp' customerId='12345'>
-          <litleTxnId>794754443359599000</litleTxnId>
+          <litleTxnId>100000000000000001</litleTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <responseTime>2015-05-18T20:54:01</responseTime>

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -111,6 +111,21 @@ class LitleTest < Test::Unit::TestCase
     assert_equal "110", response.params["response"]
   end
 
+  def test_successful_authorize_with_paypage
+    paypage_payment_method = {
+      paypage_registration_id: "cDZJcmd1VjNlYXNaSlRMTGpocVZQY1NNlYE4ZW5UTko4NU9KK3p1L1p1VzE4ZWVPQVlSUHNITG1JN2I0NzlyTg=",
+      exp_date: "1012",
+      card_validation_num: "000"
+    }
+    response = stub_comms do
+       @gateway.authorize(@amount, paypage_payment_method)
+    end.respond_with(successful_authorize_with_paypage_response)
+
+    assert_success response
+    assert_equal "100000000000000001;authorization", response.authorization
+    assert response.test?
+  end
+
   def test_failed_capture
     response = stub_comms do
       @gateway.capture(@amount, @credit_card)
@@ -326,6 +341,28 @@ class LitleTest < Test::Unit::TestCase
             <avsResult>01</avsResult>
             <cardValidationResult>M</cardValidationResult>
           </fraudResult>
+        </authorizationResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_authorize_with_paypage_response
+    %(
+      <litleOnlineResponse version='9.3' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <authorizationResponse id='ididid' reportGroup='rtpGrp' customerId='12345'>
+          <litleTxnId>794754443359599000</litleTxnId>
+          <orderId>1</orderId>
+          <response>000</response>
+          <responseTime>2015-05-18T20:54:01</responseTime>
+          <message>Approved</message>
+          <authCode>81195</authCode>
+          <tokenResponse>
+            <litleToken>1234567890123456</litleToken>
+            <tokenResponseCode>801</tokenResponseCode>
+            <tokenMessage>Account number was successfully registered</tokenMessage>
+            <type>VI</type>
+            <bin>123456</bin>
+          </tokenResponse>
         </authorizationResponse>
       </litleOnlineResponse>
     )


### PR DESCRIPTION
Ability to optionally use Litle's paypage registration id obtained via iframe, to make authorization call for token