### PR TITLE
S5: Build XML with UTF-8 encoding

### DIFF
--- a/lib/active_merchant/billing/gateways/s5.rb
+++ b/lib/active_merchant/billing/gateways/s5.rb
@@ -198,7 +198,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_xml_request
-        builder = Nokogiri::XML::Builder.new do |xml|
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
           xml.Request(version: '1.0') do
             xml.Header do
               xml.Security(sender: @options[:sender])

--- a/test/remote/gateways/remote_s5_test.rb
+++ b/test/remote/gateways/remote_s5_test.rb
@@ -32,6 +32,13 @@ class RemoteS5Test < Test::Unit::TestCase
     assert_match %r{Request successfully processed}, response.message
   end
 
+  def test_successful_purchase_with_utf_character
+    card = credit_card('4000100011112224', last_name: 'Wåhlin')
+    response = @gateway.purchase(@amount, card, @options)
+    assert_success response
+    assert_match %r{Request successfully processed}, response.message
+  end
+
   def test_successful_purchase_without_address
     response = @gateway.purchase(@amount, @credit_card, {})
     assert_success response


### PR DESCRIPTION
Otherwise Nokogiri will automatically HTML escape, in hex format, non-ASCII
characters.