### PR TITLE
Beanstream: responseType 'R' is not success

### DIFF
--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -99,6 +99,10 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
+      def success?(response)
+        response[:trnApproved] == '1' || response[:responseCode] == '1'
+      end
+
       def recurring(money, source, options = {})
         ActiveMerchant.deprecated RECURRING_DEPRECATION_MESSAGE
 

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -351,10 +351,6 @@ module ActiveMerchant #:nodoc:
         response[:message]
       end
 
-      def success?(response)
-        response[:responseType] == 'R' || response[:trnApproved] == '1' || response[:responseCode] == '1'
-      end
-
       def recurring_success?(response)
         response[:code] == '1'
       end

--- a/lib/active_merchant/billing/gateways/beanstream_interac.rb
+++ b/lib/active_merchant/billing/gateways/beanstream_interac.rb
@@ -32,6 +32,10 @@ module ActiveMerchant #:nodoc:
         commit(post)
       end
 
+      def success?(response)
+        response[:responseType] == 'R' || response[:trnApproved] == '1' || response[:responseCode] == '1'
+      end
+
       # Confirm a transaction posted back from the bank to Beanstream.
       def confirm(transaction)
         post(transaction)


### PR DESCRIPTION
Beanstream returning `responseType: R` is currently considered a `success` when in fact this is a redirect for 3dsecure: http://support.beanstream.com/docs/response-variables.htm.

There are explicit tests for `beanstream_interac` that this value is treated as success, so I kept the behaviour the same for `beanstream_interac`. Just removed `responseType == 'R'` as a success condition for `beanstream`.

Review please @ivanfer @andrewpaliga @girasquid @ntalbott 