### PR TITLE
S5: Include Recurrence tag to enable recurring transactions without CVV

### DIFF
--- a/lib/active_merchant/billing/gateways/s5.rb
+++ b/lib/active_merchant/billing/gateways/s5.rb
@@ -31,6 +31,7 @@ module ActiveMerchant #:nodoc:
           add_payment(xml, money, 'sale', options)
           add_account(xml, payment)
           add_customer(xml, payment, options)
+          add_recurrence_mode(xml, options)
         end
 
         commit(request)
@@ -50,6 +51,7 @@ module ActiveMerchant #:nodoc:
           add_payment(xml, money, 'authonly', options)
           add_account(xml, payment)
           add_customer(xml, payment, options)
+          add_recurrence_mode(xml, options)
         end
 
         commit(request)
@@ -146,6 +148,14 @@ module ActiveMerchant #:nodoc:
           xml.City       address[:city]
           xml.State      address[:state]
           xml.Country    address[:country]
+        end
+      end
+
+      def add_recurrence_mode(xml, options)
+        if options[:recurring] == true
+          xml.Recurrence(mode: "REPEATED")
+        else
+          xml.Recurrence(mode: "INITIAL")
         end
       end
 

--- a/test/remote/gateways/remote_s5_test.rb
+++ b/test/remote/gateways/remote_s5_test.rb
@@ -32,6 +32,13 @@ class RemoteS5Test < Test::Unit::TestCase
     assert_match %r{Request successfully processed}, response.message
   end
 
+  def test_successful_recurring_purchase
+    @options[:recurring] = true
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_match %r{Request successfully processed}, response.message
+  end
+
   def test_successful_purchase_with_utf_character
     card = credit_card('4000100011112224', last_name: 'Wåhlin')
     response = @gateway.purchase(@amount, card, @options)
@@ -50,6 +57,15 @@ class RemoteS5Test < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 'transaction declined (invalid card)', response.message
+  end
+
+  def test_failed_recurring_purchase
+    @options[:memo] = "800.100.153"
+    @options[:recurring] = true
+    @credit_card.verification_value = nil
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'transaction declined (invalid CVV)', response.message
   end
 
   def test_successful_authorize_without_address


### PR DESCRIPTION
@duff quick update to S5 to include the `Recurrence` tag and appropriate `mode` for future recurring transactions on a credit card that has been previously verified. Only question I have is whether or not it should also be included on the `authorize` action? I'm not 100% sure.

Also, as always with S5, the remote test is a bit "meh". I'm having to manually send what error I want back instead of S5 actually doing the validations in `TEST` mode. I've included it, but unfortunately it's very mildly helpful.