### PR TITLE
Fat Zebra: Allow extra options

### DIFF
--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -72,13 +72,18 @@ module ActiveMerchant #:nodoc:
       # amount - Integer - the amount to refund
       # txn_id - String - the original transaction to be refunded
       # reference - String - your transaction reference
-      def refund(money, txn_id, reference)
+      def refund(money, identification, options = {})
+        unless options.is_a?(Hash)
+          options = {:order_id => options}
+          ActiveMerchant.deprecated "Passing the order_id as a String is deprecated. Use a Hash instead and pass the order_id in the order_id key."
+        end
+
         post = {}
 
         add_extra_options(post, options)
         post[:amount] = money
-        post[:transaction_id] = txn_id
-        post[:reference] = reference
+        post[:transaction_id] = identification
+        post[:reference] = options[:order_id]
 
         commit(:post, "refunds", post)
       end
@@ -86,8 +91,10 @@ module ActiveMerchant #:nodoc:
       # Tokenize a credit card
       #
       # The token is returned in the Response#authorization
-      def store(creditcard)
+      def store(creditcard, options = {})
         post = {}
+
+        add_extra_options(post, options)
         add_creditcard(post, creditcard)
 
         commit(:post, "credit_cards", post)
@@ -122,7 +129,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_extra_options(post, options)
-        extra = {}
+        extra = options[:extra] || {}
         extra[:name] = options[:merchant] if options[:merchant]
         extra[:location] = options[:merchant_location] if options[:merchant_location]
         post[:extra] = extra if extra.any?

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -88,7 +88,7 @@ class RemoteFatZebraTest < Test::Unit::TestCase
   def test_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
 
-    assert response = @gateway.refund(@amount, purchase.authorization, rand(1000000).to_s)
+    assert response = @gateway.refund(@amount, purchase.authorization, order_id: rand(1000000).to_s)
     assert_success response
     assert_match %r{Approved}, response.message
   end
@@ -96,7 +96,7 @@ class RemoteFatZebraTest < Test::Unit::TestCase
   def test_invalid_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
 
-    assert response = @gateway.refund(@amount, nil, rand(1000000).to_s)
+    assert response = @gateway.refund(@amount, nil, order_id: rand(1000000).to_s)
     assert_failure response
     assert_match %r{Original transaction is required}, response.message
   end


### PR DESCRIPTION
This PR adds a small change to allow passing an extra hash in the options to enable certain functionality of the Fat Zebra gateway as documented here: http://docs.pmnts.io/display/DOC/Extra+and+Extended+Fields

As a result of this small change however, I had to deprecate the current refund method signature and allow an options hash to be passed in; this is in line with the standard active merchant method signature.

I also had to add a second parameter to the store method to accept an options hash, again this is in line with the standard store signature recommended in the comments within the Gateway base class.

Overall I think these are solid changes bringing the gateway up-to-date with the current active merchant best practices.