### PR TITLE
WePay: Use /credit_card/transfer endpoint for recurring with no CVV

### DIFF
--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -73,27 +73,34 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:client_id] = @options[:client_id]
         post[:user_name] = "#{creditcard.first_name} #{creditcard.last_name}"
-        post[:email] = options[:email]
+        post[:email] = options[:email] || "unspecified@example.com"
         post[:cc_number] = creditcard.number
-        post[:cvv] = creditcard.verification_value
-        post[:expiration_month] = creditcard.month
-        post[:expiration_year] = creditcard.year
+        post[:cvv] = creditcard.verification_value unless options[:recurring]
+        post[:expiration_month] = "#{creditcard.month}"
+        post[:expiration_year] = "#{creditcard.year}"
         post[:original_ip] = options[:ip] if options[:ip]
         post[:original_device] = options[:device_fingerprint] if options[:device_fingerprint]
         if(billing_address = (options[:billing_address] || options[:address]))
           post[:address] = {
             "address1" => billing_address[:address1],
             "city"     => billing_address[:city],
-            "state"    => billing_address[:state],
             "country"  => billing_address[:country]
           }
           if(post[:country] == "US")
             post[:address]["zip"] = billing_address[:zip]
+            post[:address]["state"] = billing_address[:state]
           else
+            post[:address]["region"] = billing_address[:state]
             post[:address]["postcode"] = billing_address[:zip]
           end
         end
-        commit('/credit_card/create', post)
+
+        if options[:recurring] == true
+          post[:client_secret] = @options[:client_secret]
+          commit('/credit_card/transfer', post)
+        else
+          commit('/credit_card/create', post)
+        end
       end
 
       private

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -913,9 +913,10 @@ webpay:
 
 # Working test credentials, no need to replace
 wepay:
-  client_id: "187493"
-  account_id: "1311201206"
-  access_token: "STAGE_4c6a319f9b6ef50e596ee3ea0b845f2fecd50fa0d8bc0b7483bd61c2018dbf5c"
+  client_id: "44716"
+  account_id: "2080478981"
+  access_token: "STAGE_67d2e41067af064af698e9cdc185c7570e4cb3191de04d8d092357c2a9120b6c"
+  client_secret: "d48fefe743"
 
 # Working test credentials with AVS/CVV support, no need to replace
 wirecard:

--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -33,6 +33,21 @@ class RemoteWepayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_sans_cvv
+    @options[:recurring] = true
+    store = @gateway.store(@credit_card, @options)
+    assert_success store
+
+    response = @gateway.purchase(@amount, store.authorization, @options)
+    assert_success response
+  end
+
+  def test_failed_purchase_sans_ccv
+    @credit_card.verification_value = nil
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+  end
+
   def test_failed_purchase_with_token
     response = @gateway.purchase(@amount, "12345", @options)
     assert_failure response


### PR DESCRIPTION
@duff: Update to WePay to support recurring transactions when CVV is no longer available since it's "verified" by the initial transaction. A few things to note:

* The `/credit_card/transfer` action is enabled on a per account basis.
* Because of point above, we had to get a new WePay account for the fixtures and have WePay enable it for that account specifically.
* Also by happenstance, fixes a bug where in the US, billing should use `state` while internationally it should use `region`. ([docs](https://www.wepay.com/developer/reference/structures#shipping_address))
* The `/credit_card/transfer` action requires expiration month and year be strings and *not* integers (despite their documentation stating they should be integers.) The [docs](https://www.wepay.com/developer/reference/credit_card) say that for regular transactions, expiration month and year should be integers as well but from the remote tests, it appears as though they can be strings as well. I swapped them to just always be strings since that works for both and I wasn't keen on changing the types depending on whether or not the `recurring` option was present. Thoughts?