### PR TITLE
Banwire: Add default email

### DIFF
--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -35,7 +35,7 @@ module ActiveMerchant #:nodoc:
       def add_customer_data(post, options)
         post[:user] = @options[:login]
         post[:phone] = options[:billing_address][:phone]
-        post[:mail] = options[:email]
+        post[:mail] = options[:email] || "unknown@example.com"
       end
 
       def add_order_data(post, options)

--- a/test/remote/gateways/remote_banwire_test.rb
+++ b/test/remote/gateways/remote_banwire_test.rb
@@ -67,7 +67,7 @@ class RemoteBanwireTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'denied', response.message
+    assert_equal 'Pago Denegado.', response.message
   end
 
   def test_invalid_login


### PR DESCRIPTION
@duff Email is a required field for banwire so added a default. Also updated the error message for one of the tests because looks like they changed their error messages from "denied" to "pago denegado" (denied in spanish). Only tests that fail right now are the amex ones, as per usual, because that's not added to our account (though I did let him know to reactivate that). 