### PR TITLE
AccountUpdater "AU" Transaction for Orbital Gateway

### DIFF
--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -354,6 +354,15 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_profile_response)
     assert_success response
   end
+  
+  def test_account_updater_eligibility
+    response = stub_comms do
+      @gateway.add_customer_profile(credit_card, :account_updater_eligibility => 'Y')
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<AccountUpdaterEligibility>Y/, data)
+    end.respond_with(successful_profile_response)
+    assert_success response
+  end
 
   def test_dont_send_customer_data_by_default
     response = stub_comms do
@@ -551,6 +560,26 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_request_account_update_for_customer_profile
+    response = stub_comms do
+      @gateway.request_account_update_for_customer_profile(@customer_ref_num)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<CustomerProfileAction>AU/, data)
+      assert_match(/<CustomerRefNum>ABC/, data)
+    end.respond_with(successful_account_updater_response)
+    assert_success response
+  end
+
+  def test_request_account_update_for_customer_profile_with_schedule_date
+    response = stub_comms do
+      @gateway.request_account_update_for_customer_profile(@customer_ref_num, {:schedule_date => 20150615})
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<CustomerProfileAction>AU/, data)
+      assert_match(/<ScheduledDate>20150615/, data)
+    end.respond_with(successful_account_updater_response)
+    assert_success response
+  end  
+
   def test_attempts_seconday_url
     @gateway.expects(:ssl_post).with(OrbitalGateway.test_url, anything, anything).raises(ActiveMerchant::ConnectionError.new("message", nil))
     @gateway.expects(:ssl_post).with(OrbitalGateway.secondary_test_url, anything, anything).returns(successful_purchase_response)
@@ -644,4 +673,9 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   def successful_void_response
     %q{<?xml version="1.0" encoding="UTF-8"?><Response><ReversalResp><MerchantID>700000208761</MerchantID><TerminalID>001</TerminalID><OrderID>2</OrderID><TxRefNum>50FB1C41FEC9D016FF0BEBAD0884B174AD0853B0</TxRefNum><TxRefIdx>1</TxRefIdx><OutstandingAmt>0</OutstandingAmt><ProcStatus>0</ProcStatus><StatusMsg></StatusMsg><RespTime>01192013172049</RespTime></ReversalResp></Response>}
   end
+
+  def successful_account_updater_response
+    %q{<?xml version="1.0" encoding="UTF-8"?><Response><AccountUpdaterResp><CustomerBin>000001</CustomerBin><CustomerMerchantID>219980</CustomerMerchantID><CustomerRefNum>50204</CustomerRefNum><CustomerProfileAction>AU</CustomerProfileAction><Status>A</Status><ScheduledDate>20150615</ScheduledDate><ProfileProcStatus>0</ProfileProcStatus><CustomerProfileMessage>Profile Request Scheduled</CustomerProfileMessage><RespTime>20150603 162649</RespTime></AccountUpdaterResp></Response>}
+  end
+  
 end


### PR DESCRIPTION
The text below, labeled "3.1.9", is copied from the Chase orbital XML guide.  The purpose of the pull request is to enhance the activemerchant gem to enable users doing transactions with Chase Orbital to send Account Updater Transactions to the Chase Orbital Gateway.  To accomplish this there were two key changes that had to be made to the "orbital.rb" class.  

1.  The build_customer_request_xml method needed to include the "AccountUpdaterEligibility" parameter.  This is the last field in the existing XML schema for the Profile schema found in file "Request_PTI54.xsd".  The flag must be set to "Y" before an Account Updater "AU" transaction can be done.

2.  The method build_customer_account_updater_request_xml was added in order to do the Account Updater Transaction, "AU", for a Profile.  The XML schema for this transaction is in the orbital reference, but can also be found in this repository in file "Request_PTI54.xsd".  

3.1.9 Chase Account Updater
This transaction is used to supplement the Account Updater service for customer profiles on a one-off exception basis. Please see section 3.3.4 Account Updater for more details. 

3.3.4 Account Updater
Fully managed Account Updater for Profiles is available to Salem (Bin 000001) merchants using customer profiles. The functionality is specifically designed to update merchant or chain level profiles housed on the gateway utilizing the Salem Account Updater process. Visa and MasterCard approval is required for participation. Please contact your account representative for additional details.
Once enabled, update requests are submitted to Visa and MasterCard according to a merchant selected schedule. Visa and MasterCard typically respond to requests within three days, inclusive of the submission day. Visa and MasterCard responses may contain information regarding new card account numbers, expiration dates, account closures, etc. Based upon the actionable information returned, the Gateway automatically updates customer profiles. A scheduled report is available that lists profiles that were updated as a part of the process.
NOTE
NOTE
If the card account number contained within a profile is invalid or not eligible for the Transaction Division’s Account Updater setup, the Account Updater request triggers a host reject.
If the card account number is invalid or the card account is closed, an associated profile is automatically suspended, preventing unsuccessful future auth or capture attempts. As with any suspended profile, the status can easily be changed to active as new information becomes available
CAUTION An Account Updater change of account number update to a profile is suppressed if the merchant initiates a change to the account number after the request is initiated and prior to the update.
The Account Updater transaction type facilitates an additional account updater request for a specific profile, outside of the selected schedule. The request is included in the next Account Updater submission unless sent with a future scheduled date (Use <scheduledDate> to do so).
A successful Account Updater transaction returns a response record stating the profile is scheduled for Account Updater. Subsequent information provided by Visa or MasterCard is used for a profile update. This information is not returned via a response file.