### PR TITLE
Adds Circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,33 @@
+machine:
+  ruby:
+    version: '2.1.0'
+
+dependencies:
+  cache_directories:
+    - 'vendor/bundle_32'
+    - 'vendor/bundle_40'
+    - 'vendor/bundle_41'
+    - 'vendor/bundle_42'
+  override:
+    - bundle check --path=vendor/bundle_32 --gemfile Gemfile.rails32 || bundle install --jobs=4 --retry=3 --gemfile Gemfile.rails32 --path=vendor/bundle_32
+    - bundle check --path=vendor/bundle_40 --gemfile Gemfile.rails40 || bundle install --jobs=4 --retry=3 --gemfile Gemfile.rails40 --path=vendor/bundle_40
+    - bundle check --path=vendor/bundle_41 --gemfile Gemfile.rails41 || bundle install --jobs=4 --retry=3 --gemfile Gemfile.rails41 --path=vendor/bundle_41
+    - bundle check --path=vendor/bundle_42 --gemfile Gemfile.rails42 || bundle install --jobs=4 --retry=3 --gemfile Gemfile.rails42 --path=vendor/bundle_42
+
+test:
+  override:
+    - bundle check --path=vendor/bundle_32 && bundle exec rake test:
+        environment:
+          BUNDLE_GEMFILE: Gemfile.rails32
+
+    - bundle check --path=vendor/bundle_40 && bundle exec rake test:
+        environment:
+          BUNDLE_GEMFILE: Gemfile.rails40
+
+    - bundle check --path=vendor/bundle_41 && bundle exec rake test:
+        environment:
+          BUNDLE_GEMFILE: Gemfile.rails41
+
+    - bundle check --path=vendor/bundle_42 && bundle exec rake test:
+        environment:
+          BUNDLE_GEMFILE: Gemfile.rails42


### PR DESCRIPTION
Circle still defaults to `1.9.3` unless otherwise specified, so let's fix that.

I picked `2.1` because it's in the middle of `2.0`, `2.1`, and `2.2` which Travis runs. Very scientific :grin:

I tested the caching, it works as expected except that because we're on a side branch of the Braintree gem, it's not cached. That should Just Work:tm: once it gets merged and they ship a new version of the gem.

FYI @jnormore @girasquid 
cc @ntalbott - I set the ActiveMerchant project on CircleCI to be public, so you guys should be able to actually see the output now instead of just the Pass/Fail and a 404 page :)
