### PR TITLE
Sage: Credit really is credit not refund

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Banwire: Add default email [anellis]
 * PayU India: Handle bad JSON [ntalbott]
 * Dibs: Pass CVC param only if there's a value [bruno]
+* Sage: Credit really is credit not refund [duff]
 
 
 == Version 1.50.0 (June 1, 2015)

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -120,22 +120,16 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def credit(money, source, options = {})
-        ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
-        refund(money, source, options)
-      end
-
-      # Performs a refund transaction.
       #
       # ==== Parameters
       #
       # * <tt>money</tt> - The amount to be authorized as an integer value in cents.
-      # * <tt>source</tt> - The CreditCard or Check object to be used as the target for the refund.
-      def refund(money, source, options = {})
+      # * <tt>source</tt> - The CreditCard or Check object to be used as the target for the credit.
+      def credit(money, source, options = {})
         if card_brand(source) == "check"
-          virtual_check.refund(money, source, options)
+          virtual_check.credit(money, source, options)
         else
-          bankcard.refund(money, source, options)
+          bankcard.credit(money, source, options)
         end
       end
 

--- a/lib/active_merchant/billing/gateways/sage/sage_bankcard.rb
+++ b/lib/active_merchant/billing/gateways/sage/sage_bankcard.rb
@@ -47,11 +47,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def credit(money, credit_card, options = {})
-        ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
-        refund(money, credit_card, options)
-      end
-
-      def refund(money, credit_card, options = {})
         post = {}
         add_credit_card(post, credit_card)
         add_transaction_data(post, money, options)

--- a/lib/active_merchant/billing/gateways/sage/sage_virtual_check.rb
+++ b/lib/active_merchant/billing/gateways/sage/sage_virtual_check.rb
@@ -22,11 +22,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def credit(money, credit_card, options = {})
-        ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
-        refund(money, source, options)
-      end
-
-      def refund(money, credit_card, options = {})
         post = {}
         add_check(post, credit_card)
         add_check_customer_data(post, options)

--- a/test/remote/gateways/remote_sage_bankcard_test.rb
+++ b/test/remote/gateways/remote_sage_bankcard_test.rb
@@ -91,8 +91,8 @@ class RemoteSageBankcardTest < Test::Unit::TestCase
     assert_equal 'INVALID T_REFERENCE', response.message
   end
   
-  def test_successful_refund
-    assert response = @gateway.refund(@amount, @visa, @options)
+  def test_successful_credit
+    assert response = @gateway.credit(@amount, @visa, @options)
     assert_success response
     assert response.test?
   end

--- a/test/remote/gateways/remote_sage_test.rb
+++ b/test/remote/gateways/remote_sage_test.rb
@@ -63,14 +63,14 @@ class RemoteSageTest < Test::Unit::TestCase
     assert_success void
   end
 
-  def test_visa_refund
-    assert response = @gateway.refund(@amount, @visa, @options)
+  def test_visa_credit
+    assert response = @gateway.credit(@amount, @visa, @options)
     assert_success response
     assert response.test?
   end
   
-  def test_check_refund
-    assert response = @gateway.refund(@amount, @check, @options)
+  def test_check_credit
+    assert response = @gateway.credit(@amount, @check, @options)
     assert_success response
     assert response.test?
   end


### PR DESCRIPTION
Revert "Sage gateway: Deprecate #credit call"

This reverts commit 425ffea0837ef592949d809735c855b647c22131.

I had deprecated the `credit` call 2 years ago thinking at the time that
the `credit` was really a refund.  In fact it was not.  It's a general
credit that isn't based on a previous transaction id.

I don't see an ability to do a standard `refund` in the Sage docs:

http://www.coderxo.com/docs/BankcardHTTPS.pdf

For now, this commit removes `refund` since the interface was broken.