### PR TITLE
Add Omise to list of supported gateways in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The [ActiveMerchant Wiki](http://github.com/Shopify/active_merchant/wikis) conta
 * [NETPAY Gateway](http://www.netpay.com.mx) - MX
 * [NMI](http://nmi.com/) - US
 * [Ogone](http://www.ogone.com/) - BE, DE, FR, NL, AT, CH
+* [Omise](https://www.omise.co/) - TH
 * [Openpay](Openpay) - MX
 * [Optimal Payments](http://www.optimalpayments.com/) - CA, US, GB
 * [Orbital Paymentech](http://chasepaymentech.com/) - US, CA


### PR DESCRIPTION
Since our payment gateway is merged, would be nice to have a link in the Readme section "Supported Payment Gateways" to our website www.omise.co 