### PR TITLE
Support for iATS ACH

### DIFF
--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -15,7 +15,9 @@ module ActiveMerchant #:nodoc:
 
       ACTIONS = {
         purchase: "ProcessCreditCardV1",
+        purchase_check: "ProcessACHEFTV1",
         refund: "ProcessCreditCardRefundWithTransactionIdV1",
+        refund_check: "ProcessACHEFTRefundWithTransactionIdV1",
         store: "CreateCreditCardCustomerCodeV1",
         unstore: "DeleteCustomerCodeV1"
       }
@@ -40,17 +42,18 @@ module ActiveMerchant #:nodoc:
         add_ip(post, options)
         add_description(post, options)
 
-        commit(:purchase, post)
+        commit((payment.is_a?(Check) ? :purchase_check : :purchase), post)
       end
 
       def refund(money, authorization, options={})
         post = {}
-        post[:transaction_id] = authorization
+        transaction_id, payment_type = split_authorization(authorization)
+        post[:transaction_id] = transaction_id
         add_invoice(post, -money, options)
         add_ip(post, options)
         add_description(post, options)
 
-        commit(:refund, post)
+        commit((payment_type == 'check' ? :refund_check : :refund), post)
       end
 
       def store(credit_card, options = {})
@@ -98,12 +101,27 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment(post, payment)
+        if payment.is_a?(Check)
+          add_check(post, payment)
+        else
+          add_credit_card(post, payment)
+        end
+      end
+
+      def add_credit_card(post, payment)
         post[:first_name] = payment.first_name
         post[:last_name] = payment.last_name
         post[:credit_card_num] = payment.number
         post[:credit_card_expiry] = expdate(payment)
         post[:cvv2] = payment.verification_value if payment.verification_value?
         post[:mop] = creditcard_brand(payment.brand)
+      end
+
+      def add_check(post, payment)
+        post[:first_name] = payment.first_name
+        post[:last_name] = payment.last_name
+        post[:account_num] = "#{payment.routing_number}#{payment.account_number}"
+        post[:account_type] = payment.account_type.upcase
       end
 
       def add_store_defaults(post)
@@ -148,7 +166,9 @@ module ActiveMerchant #:nodoc:
       def endpoints
         {
           purchase: "ProcessLink.asmx",
+          purchase_check: "ProcessLink.asmx",
           refund: "ProcessLink.asmx",
+          refund_check: "ProcessLink.asmx",
           store: "CustomerLink.asmx",
           unstore: "CustomerLink.asmx"
         }
@@ -212,9 +232,15 @@ module ActiveMerchant #:nodoc:
       def authorization_from(action, response)
         if [:store, :unstore].include?(action)
           response[:customercode]
+        elsif [:purchase_check].include?(action)
+          response[:transaction_id] ? "#{response[:transaction_id]}|check" : nil
         else
           response[:transaction_id]
         end
+      end
+
+      def split_authorization(authorization)
+        authorization.split("|")
       end
 
       def envelope_namespaces

--- a/test/remote/gateways/remote_iats_payments_test.rb
+++ b/test/remote/gateways/remote_iats_payments_test.rb
@@ -7,7 +7,7 @@ class IatsPaymentsTest < Test::Unit::TestCase
     @gateway = IatsPaymentsGateway.new(fixtures(:iats_payments))
     @amount = 100
     @credit_card = credit_card('4222222222222220')
-    @check = check
+    @check = check(routing_number: '111111111', account_number: '12345678')
     @options = {
       :order_id => generate_unique_id,
       :billing_address => address,
@@ -31,6 +31,23 @@ class IatsPaymentsTest < Test::Unit::TestCase
     assert response.message.include?('REJECT')
   end
 
+  def test_successful_check_purchase
+    response = @gateway.purchase(@amount, @check, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'Success', response.message
+    assert response.authorization
+  end
+
+  # Not possible to test failure case since tx failure is delayed from time of
+  # submission w/ ACH, even for test txs.
+  # def test_failed_check_purchase
+  #   response = @gateway.purchase(125, @check, @options)
+  #   assert_failure response
+  #   assert response.test?
+  #   assert_nil response.authorization
+  # end
+
   def test_successful_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
@@ -46,6 +63,25 @@ class IatsPaymentsTest < Test::Unit::TestCase
 
     assert refund = @gateway.refund(@amount, purchase.authorization)
     assert_failure refund
+  end
+
+  def test_successful_check_refund
+    purchase = @gateway.purchase(@amount, @check, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+
+    # This is a dubious test. Basically testing that the refund failed b/c
+    # the original purchase hadn't yet cleared. No way to test immmediate failure
+    # due to the delay in original tx processing, even for text txs.
+    assert_failure refund
+    assert_equal "REJECT: 3", refund.message
+  end
+
+  def test_failed_check_refund
+    assert refund = @gateway.refund(@amount, "invalidref")
+    assert_failure refund
+    assert_equal "REJECT: 39", refund.message
   end
 
   def test_successful_store_and_unstore


### PR DESCRIPTION
@duff @ntalbott a few notes. This PR...

* Modifies the authorization ref returned for `purchase` transactions from the pure ref returned by the gateway, e.g., `A7F8B8B3` to a composite, e.g., `A7F8B8B3|check`. Non check purchases still return the raw ref, e.g., `A7F8B8B3`. I don't believe this to be a breaking change, but could use a :+1: 
* Due to the way iATS handles test ACH transactions, it's not possible to test the failure of an ACH refund transaction in real-time (even their test ACH transactions are time-delayed). I've done my best, but not sure how else to test this aspect.

