### PR TITLE
iATS Gateway: Fix nil error on empty authorization result

### DIFF
--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -212,7 +212,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def successful_result_message?(response)
-        response[:authorization_result].start_with?('OK')
+        result = response[:authorization_result]
+        return false if result.nil?
+        result.start_with?('OK')
       end
 
       def success_from(response)
@@ -221,7 +223,7 @@ module ActiveMerchant #:nodoc:
 
       def message_from(response)
         if(!successful_result_message?(response))
-          return response[:authorization_result].strip
+          return (response[:authorization_result] || '').strip
         elsif(response[:status] == 'Failure')
           return response[:errors]
         else

--- a/test/unit/gateways/iats_payments_test.rb
+++ b/test/unit/gateways/iats_payments_test.rb
@@ -243,6 +243,15 @@ class IatsPaymentsTest < Test::Unit::TestCase
     end
   end
 
+  def test_handles_empty_authorization_result
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+    end.respond_with(empty_authorization_result_response)
+
+    assert_nil response.params[:authorization_result]
+  end
+
   private
 
   def successful_purchase_response
@@ -502,6 +511,31 @@ class IatsPaymentsTest < Test::Unit::TestCase
           </DeleteCustomerCodeV1Response>
         </soap:Body>
       </soap:Envelope>
+    XML
+  end
+
+  def empty_authorization_result_response
+    <<-XML
+<?xml version="1.0" encoding="utf-8"?>
+<soap12:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
+  <soap12:Body>
+    <ProcessCreditCardV1Response xmlns="https://www.iatspayments.com/NetGate/">
+      <ProcessCreditCardV1Result>
+        <IATSRESPONSE>
+          <STATUS>Success</STATUS>
+          <ERRORS />
+          <PROCESSRESULT>
+            <AUTHORIZATIONRESULT></AUTHORIZATIONRESULT>
+            <CUSTOMERCODE />
+            <SETTLEMENTBATCHDATE> 04/22/2014</SETTLEMENTBATCHDATE>
+            <SETTLEMENTDATE> 04/23/2014</SETTLEMENTDATE>
+            <TRANSACTIONID>A6DE6F24</TRANSACTIONID>
+          </PROCESSRESULT>
+        </IATSRESPONSE>
+      </ProcessCreditCardV1Result>
+    </ProcessCreditCardV1Response>
+  </soap12:Body>
+</soap12:Envelope>
     XML
   end
 end


### PR DESCRIPTION
Meh. I started to go down the path of forcing the authorization result to be an
empty string instead of nil, but then noticed that there are other values in the
response hash that can be nil. So, I opted for consistency and modified the code
to handle nils. I avoided the use of `try`, however.